### PR TITLE
chore: add GitHub Issues feature/bug workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,24 @@
+---
+name: Bug
+about: Report a bug — the fix design lives in this issue body
+title: ""
+labels:
+  - type/bug
+  - status/design
+---
+
+## Problem
+
+## Steps to reproduce
+
+## Expected vs. actual
+
+## Approach
+
+## Implementation plan
+<!-- Each bullet becomes a sub-issue. -->
+- [ ] step one
+
+## Testing
+
+## Risks / rollback

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,22 @@
+---
+name: Feature
+about: Propose a feature — the design spec lives in this issue body
+title: ""
+labels:
+  - type/feature
+  - status/design
+---
+
+## Problem
+
+## Goal / Non-goals
+
+## Approach
+
+## Implementation plan
+<!-- Each bullet becomes a sub-issue. -->
+- [ ] step one
+
+## Testing
+
+## Risks / rollback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,30 +153,22 @@ Every feature or bug fix starts as a **GitHub Issue**. The issue URL is the task
 
 - **Issue body** — the design spec; the single source of truth.
 - **Labels** — one `type/{feature,bug,chore}` and one `status/*` lifecycle label.
-- **Sub-issues** — the implementation plan, one per step. Create them with `gh issue create --parent <n>` (or link an existing issue with `gh issue edit`); their open/closed state drives the parent's progress bar. Requires a recent `gh` with Issues 2.0 support (verified on gh 2.96.0).
+- **Sub-issues** — the implementation plan, one per step. Create them with `gh issue create --parent <n>` (or link an existing issue with `gh issue edit`); their open/closed state drives the parent's progress bar.
 - **Comments** — status updates. Post one when you start a sub-issue and one (with the commit or PR reference) when you finish it.
 - **Closed** — done.
 
 **Lifecycle**
 
-1. **`status/design`** — create the parent issue and write the design into the body using the template below. No sub-issues or code yet.
+1. **`status/design`** — create the parent issue from the Feature or Bug template and write the design into the body. No sub-issues or code yet.
 2. **Approval gate** — a human reviews the design in the issue body. On approval, move `status/design` → `status/ready`.
 3. **`status/ready`** — create a sub-issue per plan step and start implementation. Move the parent to `status/in-progress`.
 4. **Per sub-issue** — comment that you've started, do the work on a branch, comment the commit/PR reference, then close the sub-issue.
 5. **`status/review`** — when every sub-issue is closed, open a PR with `Closes #<parent>` and move the parent to `status/review`.
 6. Merging the PR closes the parent. Done.
 
-**Issue body template**
+**Issue templates**
 
-```
-## Problem
-## Goal / Non-goals
-## Approach
-## Implementation plan   <!-- each bullet becomes a sub-issue -->
-- [ ] step one
-## Testing
-## Risks / rollback
-```
+The spec structure lives in `.github/ISSUE_TEMPLATE/` (`feature.md`, `bug.md`). Opening an issue from the GitHub **New issue** page seeds the headings and applies the `type/*` + `status/design` labels automatically. From the CLI, fill the same headings and pass the labels explicitly (below).
 
 **Commands**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,65 @@ New ADRs follow `docs/decisions/ADR-000-template.md`. Number sequentially (`ADR-
 
 When a PR implements an Accepted DR, flip its status in the same PR. A DR should never linger in Proposed once the corresponding code ships.
 
+## Feature & Bug Workflow
+
+Every feature or bug fix starts as a **GitHub Issue**. The issue URL is the task's primary reference key — put it in the branch name, the commit trailer, and the PR body. Designs live in the issue body, not in the repo tree.
+
+**What each part is for**
+
+- **Issue body** — the design spec; the single source of truth.
+- **Labels** — one `type/{feature,bug,chore}` and one `status/*` lifecycle label.
+- **Sub-issues** — the implementation plan, one per step. Create them with `gh issue create --parent <n>` (or link an existing issue with `gh issue edit`); their open/closed state drives the parent's progress bar. Requires a recent `gh` with Issues 2.0 support (verified on gh 2.96.0).
+- **Comments** — status updates. Post one when you start a sub-issue and one (with the commit or PR reference) when you finish it.
+- **Closed** — done.
+
+**Lifecycle**
+
+1. **`status/design`** — create the parent issue and write the design into the body using the template below. No sub-issues or code yet.
+2. **Approval gate** — a human reviews the design in the issue body. On approval, move `status/design` → `status/ready`.
+3. **`status/ready`** — create a sub-issue per plan step and start implementation. Move the parent to `status/in-progress`.
+4. **Per sub-issue** — comment that you've started, do the work on a branch, comment the commit/PR reference, then close the sub-issue.
+5. **`status/review`** — when every sub-issue is closed, open a PR with `Closes #<parent>` and move the parent to `status/review`.
+6. Merging the PR closes the parent. Done.
+
+**Issue body template**
+
+```
+## Problem
+## Goal / Non-goals
+## Approach
+## Implementation plan   <!-- each bullet becomes a sub-issue -->
+- [ ] step one
+## Testing
+## Risks / rollback
+```
+
+**Commands**
+
+```bash
+# Create the parent issue (design stage)
+gh issue create --title "<title>" --label type/feature,status/design --body-file design.md
+
+# Advance the lifecycle
+gh issue edit <n> --remove-label status/design --add-label status/ready
+
+# Create a sub-issue directly under the parent
+gh issue create --title "<step>" --label type/feature --parent <parent#>
+
+# ...or link/unlink an existing issue
+gh issue edit <parent#> --add-sub-issue <child#>
+gh issue edit <parent#> --remove-sub-issue <child#>
+
+# See the plan and its progress
+gh issue view <parent#> --json subIssuesSummary --jq '.subIssuesSummary | "\(.completed)/\(.total) done"'
+gh issue view <parent#> --json subIssues --jq '.subIssues.nodes[] | "#\(.number) [\(.state)] \(.title)"'
+
+# Post status updates and close
+gh issue comment <n> --body "Started."
+gh issue comment <n> --body "Done in <commit-sha>."
+gh issue close <n>
+```
+
 ## Release Process
 
 Releases are driven by git tags. Do not create releases manually with `gh release create`.


### PR DESCRIPTION
## Problem

Beads is gone (#210), leaving no defined way to capture designs or track feature/bug work. We want a simple, self-contained flow with no dependency on any external methodology.

## Approach

Use **GitHub Issues** as the system of record:

- **Issue body** = the design spec (single source of truth), seeded from a `.github/ISSUE_TEMPLATE/`.
- **Native sub-issues** = the implementation plan, one per step; their open/closed state drives the parent's progress bar.
- **`type/*` + `status/*` labels** = kind of work + lifecycle stage.
- **Comments** = status updates agents post as they start/finish sub-issues.
- The **issue URL** is the task's primary reference key (branch name, commit trailer, PR body).

## What's in this PR

- **`.github/ISSUE_TEMPLATE/feature.md` + `bug.md`** — the design-spec structure. The New issue page seeds the headings and auto-applies `type/*` + `status/design`. The bug template adds Steps to reproduce / Expected vs. actual.
- **AGENTS.md → "Feature & Bug Workflow"** — the lifecycle, a pointer to the templates, and the exact `gh` commands.

Sub-issues use `gh`'s **native Issues 2.0 flags** (shipped in cli/cli#13057, verified on gh 2.96.0) — `gh issue create --parent`, `gh issue edit --add-sub-issue`, `gh issue view --json subIssues,subIssuesSummary`. These take plain issue numbers, so **no helper script is needed** (an earlier revision added one; removed once native support was confirmed per cli/cli#10298).

## Repo labels (applied out-of-band, not in git)

Created a clean set and removed the beads/`spec/*` leftovers that #210 didn't touch:

- **Added:** `type/{feature,bug,chore}`, `status/{design,ready,in-progress,review,blocked}`
- **Deleted:** `beads`, `blocked`, `type/{task,epic,decision}`, `status/{open,closed,in_progress,deferred,hooked,pinned}`, `spec/{brainstorming,ready,review}`

## Testing

- Native sub-issue commands verified against the live API on gh 2.96.0.
- Issue-template YAML front-matter validated (parses; correct labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjqJHXStjUc6gknCFYJZ5x