### PR TITLE
feat: just one-command dev workflow (#231)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,81 @@
+# Sidereal v2 backend
+
+The Rust backend for Sidereal v2, a cargo workspace living as a sibling subtree
+alongside the existing TypeScript stack (`apps/`, `packages/`). See
+[`docs/architecture/README.md`](../docs/architecture/README.md) and
+[ADR-002](../docs/decisions/ADR-002-core-domain-pack-split.md) for the design.
+
+## Crate layout
+
+```
+backend/
+  Cargo.toml            # workspace manifest (members + shared dep versions)
+  rust-toolchain.toml   # pins stable 1.85
+  crates/
+    plugin-abi/         # public plugin contracts a third-party pack also codes against
+    core/               # domain-agnostic engine; builds on plugin-abi (no astro)
+    server/             # thin axum binary; serves GET /healthz, wires core + packs
+    packs/
+      astro/            # first-party pack; depends on plugin-abi ONLY, never core
+  scripts/
+    check-arch.sh       # dependency-direction lint: forbids packs/astro -> core
+```
+
+## Prerequisites
+
+- **[rustup](https://rustup.rs/)** — installs cargo and, on first build, auto-selects
+  the toolchain pinned in `rust-toolchain.toml` (stable 1.85). A C linker is also
+  required (`build-essential` on Debian/Ubuntu, Xcode CLT on macOS).
+- **[just](https://github.com/casey/just)** — the command runner spanning both stacks:
+  `cargo install just` (or a system package: `apt install just`, `brew install just`,
+  `scoop install just`).
+- **[Node.js](https://nodejs.org/) 20+** — only needed to run the frontend half of
+  `just dev`.
+
+## Zero-to-running
+
+From the **repository root**:
+
+```bash
+just dev
+```
+
+That starts the Rust backend and the Vite frontend together. The backend serves
+its liveness probe once up:
+
+```bash
+curl localhost:5000/healthz     # -> 200 {"status":"ok"}
+```
+
+## Recipes
+
+`just` recipes live in the root `justfile`; `just --list` self-documents them.
+
+| Recipe | What it does |
+|---|---|
+| `just dev` | Backend + frontend together (zero-to-running). |
+| `just backend` | Rust backend only. |
+| `just frontend` | Vite frontend only. |
+| `just check` | `cargo fmt --check` + `clippy -D warnings` + `cargo test` + arch lint. |
+
+A Rust-only contributor can skip `just` and call cargo directly from `backend/`
+(the pinned toolchain is auto-selected there):
+
+```bash
+cd backend
+cargo run -p sidereal-server    # boot the server
+cargo test                      # run the workspace tests
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `5000` | Server listen port. |
+
+## Notes
+
+- The `justfile` lives at the repo root (not here) because `just dev` spans both
+  the Rust backend and the TypeScript frontend.
+- `plugin-abi` is intentionally minimal in M0 — trait stubs, not a frozen ABI;
+  it is expected to churn until M2.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,25 @@
+# Sidereal — single command front door spanning the Rust backend and the
+# Vite frontend. See https://github.com/casey/just and backend/README.md.
+
+# Show available recipes.
+default:
+    @just --list
+
+# Zero-to-running: backend + frontend together.
+dev:
+    npx concurrently -n backend,frontend -c blue,green \
+      "cargo run -p sidereal-server --manifest-path backend/Cargo.toml" \
+      "npm run dev:frontend"
+
+# Run the Rust backend only (serves GET /healthz).
+backend:
+    cargo run -p sidereal-server --manifest-path backend/Cargo.toml
+
+# Run the Vite frontend only.
+frontend:
+    npm run dev:frontend
+
+# Backend checks: format, lint (deny warnings), tests, dependency-direction lint.
+check:
+    cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test
+    backend/scripts/check-arch.sh


### PR DESCRIPTION
Closes #231. Part of #216 (M0 scaffolding workstream).

> **Stacked on #236 (#229).** Base is `feat/229-axum-healthz` so the diff shows only #231's change; will retarget as the stack merges down.

Single front door spanning both stacks.

## Changes
- Root `justfile`: `dev` (concurrently backend + vite), `backend`, `frontend`, `check` (fmt + clippy `-D warnings` + test + arch lint), and a `default` recipe that runs `just --list`.
- `backend/README.md`: prerequisites (rustup, `cargo install just`, Node 20+) and zero-to-running steps.
- `dev` / `frontend` reuse the existing `npm run dev:frontend` (vite); `concurrently` is already a dev dependency.

## Acceptance
- [x] `just dev` starts backend + frontend; `GET /healthz` reachable (verified: `200 {"status":"ok"}`).
- [x] `just --list` self-documents recipes.

Also verified: `just check` green (fmt + clippy `-D warnings` + test + arch lint).

## Note
#231 depended on #229 (the `/healthz` endpoint), so #229 was implemented first and this PR stacks on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmcxCHGfs2b9mgc4ee4SJi