### PR TITLE
feat: plugin-abi trait stubs + astro registration (#230)

### DIFF
--- a/backend/crates/packs/astro/src/lib.rs
+++ b/backend/crates/packs/astro/src/lib.rs
@@ -5,8 +5,49 @@
 //! use — and never against `core` internals. That direction is enforced by
 //! `backend/scripts/check-arch.sh`.
 //!
-//! M0 is a registration stub only: no FITS reading, no plate solving, no
-//! ingest. Real registration through the plugin registry lands in #230.
+//! M0 is registration only: the components below are id-bearing stubs with no
+//! behaviour yet (no FITS reading, no plate solving, no ingest).
+
+use sidereal_plugin_abi::{Operator, Pack, Registry, Sink, Source};
+
+/// The astrophotography domain pack.
+pub struct AstroPack;
+
+impl Pack for AstroPack {
+    fn id(&self) -> &str {
+        "astro"
+    }
+
+    fn register(&self, registry: &mut Registry) {
+        registry.register_source(Box::new(FitsSource));
+        registry.register_operator(Box::new(PlateSolveOperator));
+        registry.register_sink(Box::new(ImmichSink));
+    }
+}
+
+/// Reads FITS/XISF frames into assets (M0 stub).
+struct FitsSource;
+impl Source for FitsSource {
+    fn id(&self) -> &str {
+        "astro.fits"
+    }
+}
+
+/// Plate-solves frames against a catalog (M0 stub).
+struct PlateSolveOperator;
+impl Operator for PlateSolveOperator {
+    fn id(&self) -> &str {
+        "astro.plate-solve"
+    }
+}
+
+/// Exports processed frames to Immich (M0 stub).
+struct ImmichSink;
+impl Sink for ImmichSink {
+    fn id(&self) -> &str {
+        "astro.immich"
+    }
+}
 
 /// The plugin-ABI version this pack was built against.
 pub fn abi_version() -> u32 {

--- a/backend/crates/packs/astro/tests/registration.rs
+++ b/backend/crates/packs/astro/tests/registration.rs
@@ -1,0 +1,16 @@
+//! Proves the astro pack registers and is discoverable purely through
+//! `plugin-abi` — no `core` involved (astro does not even depend on it).
+
+use sidereal_pack_astro::AstroPack;
+use sidereal_plugin_abi::{Pack, Registry};
+
+#[test]
+fn astro_pack_registers_and_is_discoverable() {
+    let mut registry = Registry::new();
+    AstroPack.register(&mut registry);
+
+    assert_eq!(AstroPack.id(), "astro");
+    assert!(registry.source_ids().contains(&"astro.fits"));
+    assert!(registry.operator_ids().contains(&"astro.plate-solve"));
+    assert!(registry.sink_ids().contains(&"astro.immich"));
+}

--- a/backend/crates/plugin-abi/src/lib.rs
+++ b/backend/crates/plugin-abi/src/lib.rs
@@ -2,11 +2,88 @@
 //!
 //! This crate holds the interface a domain pack codes against — the same
 //! surface a third-party pack would use. The first-party astro pack depends on
-//! this crate and never on `core` internals (ADR-002). Trait stubs
-//! (`Source`/`Operator`/`Sink`, `AssetContext`, manifest/capability types) land
-//! in a follow-up (#230); for now this is a placeholder that establishes the
-//! seam so downstream crates can compile against it.
+//! this crate and never on `core` internals (ADR-002).
+//!
+//! The contracts here are intentionally minimal for M0 — trait stubs and a
+//! registry that make the registration path *real*, not a frozen ABI. They are
+//! expected to churn until M2 freezes them.
 
 /// Version of the plugin ABI surface. Bumped when the contracts change; `0`
 /// marks the pre-freeze M0 skeleton.
 pub const ABI_VERSION: u32 = 0;
+
+/// Produces assets into the system (e.g. a FITS reader).
+pub trait Source: Send + Sync {
+    /// Stable, namespaced identifier, e.g. `"astro.fits"`.
+    fn id(&self) -> &str;
+}
+
+/// Transforms assets (e.g. plate solving).
+pub trait Operator: Send + Sync {
+    /// Stable, namespaced identifier, e.g. `"astro.plate-solve"`.
+    fn id(&self) -> &str;
+}
+
+/// Exports assets to an external system (e.g. Immich).
+pub trait Sink: Send + Sync {
+    /// Stable, namespaced identifier, e.g. `"astro.immich"`.
+    fn id(&self) -> &str;
+}
+
+/// The registry a pack contributes its components through — the same entry
+/// point a third-party pack uses. Packs register here and never touch `core`
+/// internals.
+#[derive(Default)]
+pub struct Registry {
+    sources: Vec<Box<dyn Source>>,
+    operators: Vec<Box<dyn Operator>>,
+    sinks: Vec<Box<dyn Sink>>,
+}
+
+impl Registry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a [`Source`].
+    pub fn register_source(&mut self, source: Box<dyn Source>) {
+        self.sources.push(source);
+    }
+
+    /// Register an [`Operator`].
+    pub fn register_operator(&mut self, operator: Box<dyn Operator>) {
+        self.operators.push(operator);
+    }
+
+    /// Register a [`Sink`].
+    pub fn register_sink(&mut self, sink: Box<dyn Sink>) {
+        self.sinks.push(sink);
+    }
+
+    /// Ids of all registered sources, in registration order.
+    pub fn source_ids(&self) -> Vec<&str> {
+        self.sources.iter().map(|s| s.id()).collect()
+    }
+
+    /// Ids of all registered operators, in registration order.
+    pub fn operator_ids(&self) -> Vec<&str> {
+        self.operators.iter().map(|o| o.id()).collect()
+    }
+
+    /// Ids of all registered sinks, in registration order.
+    pub fn sink_ids(&self) -> Vec<&str> {
+        self.sinks.iter().map(|s| s.id()).collect()
+    }
+}
+
+/// Implemented by a domain pack to contribute its components. The host builds a
+/// [`Registry`] and calls [`Pack::register`] on each pack; this is the entire
+/// contact surface between a pack and the host.
+pub trait Pack {
+    /// Stable pack identifier, e.g. `"astro"`.
+    fn id(&self) -> &str;
+
+    /// Register this pack's sources, operators, and sinks into `registry`.
+    fn register(&self, registry: &mut Registry);
+}


### PR DESCRIPTION
Closes #230. Part of #216 (M0 scaffolding workstream).

> **Stacked on #235 (#228).** Base is `feat/228-cargo-workspace-skeleton`; will retarget to `main` once #235 merges. Independent of #229/#231 — touches only `plugin-abi` and `packs/astro`.

Makes the contract path real: the astro pack registers through `plugin-abi`, not a private core API.

## Changes
- **plugin-abi**: minimal `Source` / `Operator` / `Sink` trait stubs, a `Registry` packs register into, and a `Pack` trait (the whole pack↔host contact surface). Intentionally minimal — not a frozen ABI; expected to churn until M2.
- **packs/astro**: `AstroPack` implements `Pack` and registers id-bearing stubs — `astro.fits` (Source), `astro.plate-solve` (Operator), `astro.immich` (Sink) — through the registry. No behaviour yet.
- **Test** (`tests/registration.rs`): builds a `Registry`, registers `AstroPack`, and asserts the components are discoverable — purely through `plugin-abi`, no `core`.

## Acceptance
- [x] Test confirms `packs/astro` registers and is discoverable purely through `plugin-abi`.

Also verified: fmt / clippy `-D warnings` / test green; the dependency-direction lint still confirms astro depends on `plugin-abi` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmcxCHGfs2b9mgc4ee4SJi