### PR TITLE
ci: backend-rs workflow (#232)

### DIFF
--- a/.github/workflows/backend-rs.yml
+++ b/.github/workflows/backend-rs.yml
@@ -1,0 +1,44 @@
+name: backend-rs
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-rs.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: fmt · clippy · test · build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install pinned Rust toolchain
+        run: rustup show
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test
+
+      - name: Build
+        run: cargo build
+
+      - name: Dependency-direction lint
+        run: bash scripts/check-arch.sh


### PR DESCRIPTION
Closes #232. Part of #216 (M0 scaffolding workstream).

> **Stacked on #235 (#228).** Base is `feat/228-cargo-workspace-skeleton`; will retarget to `main` once #235 merges. Independent of #229/#230/#231 — adds one workflow file.

Keeps the two stacks' pipelines independent: a dedicated Rust workflow for the backend, separate from the existing TS/Docker workflows.

## Changes
- New `.github/workflows/backend-rs.yml`, one `check` job on `ubuntu-latest` with `working-directory: backend`:
  - `rustup show` installs the pinned 1.85 toolchain (+ rustfmt/clippy) from `rust-toolchain.toml`.
  - `Swatinem/rust-cache@v2` (`workspaces: backend`) caches cargo artifacts.
  - `cargo fmt --check` → `clippy --all-targets -- -D warnings` → `test` → `build`, then the ADR-002 dependency-direction lint (`bash scripts/check-arch.sh`).
- Triggers on `pull_request` touching `backend/**` **or** the workflow file itself (so the workflow is exercised on its own introducing PR).
- Existing TS/Docker workflows untouched.

## Acceptance
- [x] Workflow green on a PR that touches `backend/**` (this PR — verified via the run below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmcxCHGfs2b9mgc4ee4SJi