### PR TITLE
docs: close ADR-002 (core/domain-pack seam) (#234)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -352,13 +352,13 @@ force the choice. ADR-004 picks on other grounds.
 ## Open seams
 
 Points where a reader would otherwise assume something is settled. Each has an ADR; all are M0 work.
-ADR-006 was accepted during review; the rest record a leaning and fill in their Decision section when
+ADR-002 and ADR-006 are accepted; the rest record a leaning and fill in their Decision section when
 approved.
 
 | # | Seam | Affects | Status / leaning |
 |---|---|---|---|
 | [ADR-001](../decisions/ADR-001-plugin-boundary.md) | **Plugin contract and execution profiles** — built-in Rust · embedded Rhai · external provider | Installation, capability isolation, performance, non-Rust authorship | Capability-oriented hybrid |
-| [ADR-002](../decisions/ADR-002-core-domain-pack-split.md) | **Core / domain-pack seam** — where exactly it falls, and whether packs are compiled in or loaded | How much of the astro feature set is separable work | None stated |
+| [ADR-002](../decisions/ADR-002-core-domain-pack-split.md) | **Core / domain-pack seam** — where exactly it falls, and whether packs are compiled in or loaded | How much of the astro feature set is separable work | **Accepted** — astro compiled in as `packs/astro` coding against `plugin-abi` (Option A; dynamic whole-pack swap deferred); session a core concept with pack vocabulary; equipment pack-owned; frontend API + facet schemas only (no dynamic frontend ABI in v2.0) |
 | [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md) | **Storage layout and identity** — stable Assets, immutable AssetVersions, on-disk tree | Lineage integrity, dedup, revision retention, rename cost | Stable Asset plus immutable versions |
 | [ADR-004](../decisions/ADR-004-database-engine-and-schema.md) | **Database engine and schema strategy** | Deployment story, facet indexing, migration tooling | Keep SQLite-default / Postgres-optional |
 | [ADR-005](../decisions/ADR-005-frontend-continuity.md) | **Frontend continuity** — evolve the existing React app against the new API, or start fresh | Whether M5 begins from a working codebase; contributor continuity | None stated |
@@ -476,7 +476,7 @@ before import. After cutover, rollback restores that backup. The importer remain
 ## What this document is not
 
 - **Not a plan.** Milestones are sub-issues under #213; the plan lives there.
-- **Not fully accepted.** #213 is `status/ready`, but seven of the eight ADRs are still Proposed.
+- **Not fully accepted.** #213 is `status/ready`, but six of the eight ADRs are still Proposed.
   Until each Decision section is filled in, the seams they cover describe a leaning.
 - **Not a v0.10.x reference.** [Where we are](#where-we-are) is a summary; the authoritative record of
   current behaviour is the [analysis package](https://github.com/sidereal-io/sidereal-analysis).

--- a/docs/decisions/ADR-002-core-domain-pack-split.md
+++ b/docs/decisions/ADR-002-core-domain-pack-split.md
@@ -1,6 +1,6 @@
 # 002: Core / Domain-Pack Seam
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-29
 **Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The [architecture](../architecture/README.md#core-and-domain-packs) commits to a domain-agnostic core with astrophotography as the first domain pack. This ADR fixes where the seam actually falls and how packs are delivered.
 
@@ -73,4 +73,37 @@ Specific calls to make explicit:
 
 ## Decision
 
-[Filled in after review.]
+The concrete crate skeleton (#228–#233) makes this seam physical, so ADR-002 is
+decided now rather than deferred. All four calls below are taken in the
+reversible-safe direction — compiled-in → loadable, pack-owned → core, and
+API-only → UI-ABI are each additive later, while the reverse would be a
+migration.
+
+**1. Seam = Option A.** The first-party astro pack is compiled into v2.0 as the
+`packs/astro` crate. It codes against the public `plugin-abi` contract — the same
+Source/Operator/Sink traits and registry a third-party pack would use — and never
+against `core` internals; that direction is enforced structurally (astro depends on
+`plugin-abi` only) and by a dependency-direction lint. The pack uses ADR-001's
+built-in Rust execution profile and implements the same semantic contracts and
+conformance fixtures a third party would. Dynamically replacing the whole domain
+pack is **deferred, not designed out**: the contract boundary exists today; only the
+dynamic loader is absent.
+
+**2. Session = core concept, pack vocabulary.** Core knows the generic notion of a
+time-bounded, subject-bearing Collection. The astro pack supplies the "session"
+vocabulary and its facet values. Core does not hardcode astronomy, and the pack does
+not reinvent Collections.
+
+**3. Equipment = pack-owned.** Every equipment field is astro-shaped, so equipment
+lives entirely in the astro pack and core stays domain-free. Promoting a concept to
+core later is cheap and additive; pushing astro fields into core now would be a
+migration to undo.
+
+**4. Frontend = API + descriptive facet schemas only.** Packs contribute backend
+behaviour and facet schemas carrying render metadata (type, unit, label,
+filterability, render hint). The single TypeScript frontend renders facets
+generically; first-party astro views (sky map, visibility) live in the shared React
+app. There is **no dynamic frontend plugin ABI in v2.0**; dynamic UI contribution is
+deferred to M7+. This keeps M5 an independently-moving React app and is consistent
+with ADR-001's caution against a published dynamic ABI. Adding a UI-contribution
+mechanism later is purely additive.


### PR DESCRIPTION
Closes #234. Part of #216 (M0 scaffolding workstream).

Docs-only, and independent of the backend code stack — the concrete crate skeleton (#228–#233) makes the core/domain-pack seam physical, so ADR-002 is flipped from Proposed to Accepted.

## Changes
- **`docs/decisions/ADR-002-core-domain-pack-split.md`**: Status Proposed → **Accepted**; Decision section written with the four calls:
  1. **Seam = Option A** — astro compiled in as `packs/astro`, coding against `plugin-abi` (built-in Rust profile); dynamic whole-pack replacement **deferred, not designed out**.
  2. **Session** = core concept (time-bounded, subject-bearing Collection); pack supplies vocabulary.
  3. **Equipment** = pack-owned; core stays domain-free.
  4. **Frontend** = API + descriptive facet schemas only; **no dynamic frontend ABI in v2.0**; astro views live in the shared React app; dynamic UI contribution deferred to M7+.
- **`docs/architecture/README.md`**: Open Seams table row for ADR-002 updated from "None stated" to the decided outcome; table intro now names ADR-002 alongside ADR-006 as accepted; the "still Proposed" ADR count corrected (seven → six).

## Acceptance
- [x] ADR-002 Status = Accepted with Decision section written.
- [x] Architecture README updated to match.

Note: there is no dedicated inline `◇` marker for ADR-002 in the README — its leaning lived in the Open Seams table (per the legend, a table entry *is* the leaning), so that row plus the two lines it made stale are the edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmcxCHGfs2b9mgc4ee4SJi