### PR TITLE
docs: accept M0 ADRs 001/003/004/007/008 (#213)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,43 +140,31 @@ See `.env.example` and `.env.worker.example` for the full list.
 
 ## Decision Records
 
-An ADR captures the **why** — the context, constraints, and trade-offs behind a decision. Code shows
-what was built; the ADR explains why it was built this way and what alternatives were rejected. Write to
-that purpose, not to log every change.
+An ADR captures the **why** behind a decision — its context, constraints, trade-offs, and rejected
+alternatives. It is not a changelog. Three tiers keep decisions out of prose without over-writing ADRs:
 
-**Write one at most for:** a framework, library, or major dependency; a data model or database schema;
-an authentication strategy; an API architecture (REST vs. GraphQL vs. tRPC); a build tool, hosting
-platform, or infrastructure choice; or anything that would be **expensive to reverse**. If none of those
-fit and a reasonable person wouldn't argue for a different approach, don't write one.
+- **ADR** — a real fork, or an expensive-to-reverse call: a framework/library/dependency, a data model
+  or schema, an auth strategy, an API architecture, an infra/hosting choice. Lives in `docs/decisions/`.
+- **Design fact** — settled, with no significant alternative: a one-liner under *Key design decisions*
+  in [`docs/architecture/README.md`](docs/architecture/README.md). Promote it to an ADR if a contested
+  *why* later emerges.
+- **Scope / premise** — the RFC or issue, not here.
 
-Three tiers keep decisions out of prose without over-writing ADRs: a real fork or an expensive-to-reverse
-call is an **ADR**; a settled call with no significant alternative goes as a one-line **design fact**
-under *Key design decisions* in [`docs/architecture/README.md`](docs/architecture/README.md); product
-scope and premises live in the **RFC/issue**. A design fact that grows a contested *why* gets promoted to
-an ADR.
-
-New ADRs follow `docs/decisions/ADR-000-template.md`. Number sequentially (`ADR-NNN-short-slug.md`). Keep
-it concise and the options concrete — code or config snippets where they clarify a trade-off.
+New ADRs follow `docs/decisions/ADR-000-template.md`, numbered `ADR-NNN-slug.md`. Keep them concise and
+their options concrete.
 
 ### Lifecycle
 
-- **Proposed** — authored, not yet reviewed.
-- **Accepted** — approved; implementation may proceed.
-- **Superseded by NNN** — reversed or replaced; keep the original file, add a pointer to the replacement.
-- **Archived** — no longer applies; prefix title with [Archived], add a one-line note under Status.
+**Proposed** (authored) → **Accepted** (implementation may proceed) → **Superseded by NNN** (keep the
+file, point to the replacement) or **Archived** (prefix the title `[Archived]`, note it under Status).
+Flip status in the same PR that implements the DR — none should linger in Proposed once code ships.
 
-When a PR implements an Accepted DR, flip its status in the same PR. A DR should never linger in Proposed once the corresponding code ships.
+### Open ADRs block design — STOP
 
-### Open ADRs block design — STOP and decide first
-
-A **Proposed** ADR is a decision that has *not* been made. Sitting in Proposed indefinitely is fine —
-until its subject matter comes up in a design.
-
-**Before designing any feature or sub-issue, scan `docs/decisions/` for a Proposed ADR whose scope
-touches the design** — i.e. one the design would have to assume an answer to. If one exists, **STOP.**
-Don't design around it, pick a default, or leave the choice implicit. Work through it with the operator,
-get it Accepted (write the Decision, flip the status), *then* design on top. An open-ended design that
-silently assumes an undecided ADR is the exact failure this rule prevents.
+A Proposed ADR is a decision *not yet made*; sitting there indefinitely is fine until its subject comes
+up. **Before designing a feature or sub-issue, scan `docs/decisions/` for a Proposed ADR the design
+would have to assume an answer to. If one exists, STOP** — don't design around it or pick a default.
+Work it through with the operator, get it Accepted, then design on top.
 
 ## Feature & Bug Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,26 @@ New ADRs follow `docs/decisions/ADR-000-template.md`. Number sequentially (`ADR-
 
 When a PR implements an Accepted DR, flip its status in the same PR. A DR should never linger in Proposed once the corresponding code ships.
 
+### Open ADRs block design — STOP and decide first
+
+A **Proposed** ADR is a decision that has *not* been made. It is fine for an ADR to sit in Proposed
+indefinitely — until its subject matter actually comes up.
+
+**Before designing any feature or sub-issue, check `docs/decisions/` for a Proposed ADR whose scope
+touches the design. If one exists, STOP.** Do not design around it, do not pick a plausible default,
+do not leave the choice implicit for later. **Work through the decision with the operator and get the
+ADR Accepted first**, then continue the design on top of the accepted decision.
+
+Concretely, when you start a design:
+
+1. Scan `docs/decisions/` and list every ADR still marked **Proposed**.
+2. For each, ask: *would this design have to assume an answer this ADR is meant to decide?* If yes,
+   the ADR is in scope.
+3. If any in-scope ADR is still Proposed, **halt the design**, surface it to the operator, and drive
+   it to Accepted (write the Decision, flip the status) **before** writing any design that depends on
+   it. An open-ended design that silently assumes an undecided ADR is the exact failure this rule
+   exists to prevent.
+
 ## Feature & Bug Workflow
 
 Every feature or bug fix starts as a **GitHub Issue**. The issue URL is the task's primary reference key — put it in the branch name, the commit trailer, and the PR body. Designs live in the issue body, not in the repo tree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,12 @@ an authentication strategy; an API architecture (REST vs. GraphQL vs. tRPC); a b
 platform, or infrastructure choice; or anything that would be **expensive to reverse**. If none of those
 fit and a reasonable person wouldn't argue for a different approach, don't write one.
 
+Three tiers keep decisions out of prose without over-writing ADRs: a real fork or an expensive-to-reverse
+call is an **ADR**; a settled call with no significant alternative goes as a one-line **design fact**
+under *Key design decisions* in [`docs/architecture/README.md`](docs/architecture/README.md); product
+scope and premises live in the **RFC/issue**. A design fact that grows a contested *why* gets promoted to
+an ADR.
+
 New ADRs follow `docs/decisions/ADR-000-template.md`. Number sequentially (`ADR-NNN-short-slug.md`). Keep
 it concise and the options concrete — code or config snippets where they clarify a trade-off.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,9 +140,17 @@ See `.env.example` and `.env.worker.example` for the full list.
 
 ## Decision Records
 
-When you encounter a design decision with multiple valid approaches, suggest a decision record. They're most useful when a reasonable person could argue for a different approach.
+An ADR captures the **why** — the context, constraints, and trade-offs behind a decision. Code shows
+what was built; the ADR explains why it was built this way and what alternatives were rejected. Write to
+that purpose, not to log every change.
 
-New ADRs follow `docs/decisions/ADR-000-template.md`. Number sequentially (`ADR-NNN-short-slug.md`). Keep options concrete — include code snippets or config examples where they clarify trade-offs.
+**Write one at most for:** a framework, library, or major dependency; a data model or database schema;
+an authentication strategy; an API architecture (REST vs. GraphQL vs. tRPC); a build tool, hosting
+platform, or infrastructure choice; or anything that would be **expensive to reverse**. If none of those
+fit and a reasonable person wouldn't argue for a different approach, don't write one.
+
+New ADRs follow `docs/decisions/ADR-000-template.md`. Number sequentially (`ADR-NNN-short-slug.md`). Keep
+it concise and the options concrete — code or config snippets where they clarify a trade-off.
 
 ### Lifecycle
 
@@ -155,23 +163,14 @@ When a PR implements an Accepted DR, flip its status in the same PR. A DR should
 
 ### Open ADRs block design — STOP and decide first
 
-A **Proposed** ADR is a decision that has *not* been made. It is fine for an ADR to sit in Proposed
-indefinitely — until its subject matter actually comes up.
+A **Proposed** ADR is a decision that has *not* been made. Sitting in Proposed indefinitely is fine —
+until its subject matter comes up in a design.
 
-**Before designing any feature or sub-issue, check `docs/decisions/` for a Proposed ADR whose scope
-touches the design. If one exists, STOP.** Do not design around it, do not pick a plausible default,
-do not leave the choice implicit for later. **Work through the decision with the operator and get the
-ADR Accepted first**, then continue the design on top of the accepted decision.
-
-Concretely, when you start a design:
-
-1. Scan `docs/decisions/` and list every ADR still marked **Proposed**.
-2. For each, ask: *would this design have to assume an answer this ADR is meant to decide?* If yes,
-   the ADR is in scope.
-3. If any in-scope ADR is still Proposed, **halt the design**, surface it to the operator, and drive
-   it to Accepted (write the Decision, flip the status) **before** writing any design that depends on
-   it. An open-ended design that silently assumes an undecided ADR is the exact failure this rule
-   exists to prevent.
+**Before designing any feature or sub-issue, scan `docs/decisions/` for a Proposed ADR whose scope
+touches the design** — i.e. one the design would have to assume an answer to. If one exists, **STOP.**
+Don't design around it, pick a default, or leave the choice implicit. Work through it with the operator,
+get it Accepted (write the Decision, flip the status), *then* design on top. An open-ended design that
+silently assumes an undecided ADR is the exact failure this rule prevents.
 
 ## Feature & Bug Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ alternatives. It is not a changelog. Three tiers keep decisions out of prose wit
 
 - **ADR** — a real fork, or an expensive-to-reverse call: a framework/library/dependency, a data model
   or schema, an auth strategy, an API architecture, an infra/hosting choice. Lives in `docs/decisions/`.
-- **Design fact** — settled, with no significant alternative: a one-liner under *Key design decisions*
+- **Design fact** — settled, with no significant alternative: a one-liner under *Design facts*
   in [`docs/architecture/README.md`](docs/architecture/README.md). Promote it to an ADR if a contested
   *why* later emerges.
 - **Scope / premise** — the RFC or issue, not here.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,16 +1,18 @@
 # Sidereal Architecture
 
-**Status:** Proposed · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) (`status/ready`) · **Last updated:** 2026-08-19
+**Architecture reference:** current · **Open architecture decisions:** [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend), [ADR-011](../decisions/ADR-011-storage-tree-layout.md) (storage tree) · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) · **Last updated:** 2026-08-19
 
-> **Why this lives in the repo.** Feature designs live in issue bodies; this is different. It is the
-> standing answer to "what is this system and where is it going," and it must outlive the issue that
-> produced it. #213 is the *proposal*; this is the *reference*. Where the [decision
-> index](#architecture-decisions) below marks an ADR **Proposed**, the corresponding approach here is a
-> leaning, not a commitment.
-
-This document is a **map**: the north star, a glossary of the load-bearing concepts, and pointers to
-the ADRs and specs that own each decision. It does not restate them — [`docs/decisions/`](../decisions/)
-is the source of truth for *why* each call was made.
+> **How to use this map.** This file owns the **architectural map** — the north star and a glossary of
+> the load-bearing concepts — and points to, without restating, the documents that own each thing:
+>
+> - **Why each decision was made** → the ADRs in [`docs/decisions/`](../decisions/); the
+>   [decision index](#architecture-decisions) below is their canonical status.
+> - **The plan** — milestones, sequencing → [roadmap.md](roadmap.md) and [RFC #213](https://github.com/sidereal-io/sidereal/issues/213).
+> - **Cutover execution** — checklist, rollback → [migration.md](migration.md).
+> - **Current v0.10.x behaviour** → the [analysis package](https://github.com/sidereal-io/sidereal-analysis) — an inventory, not a compatibility contract.
+>
+> Where the decision index marks an ADR **Proposed**, the approach here is a leaning, not a commitment.
+> Change this map through an ADR, then update it in the same PR.
 
 ## Where we are
 
@@ -50,25 +52,6 @@ astro product.
 
 Seven load-bearing additions that do not exist today; everything else in v2 is a consequence of them.
 
-```mermaid
-graph TD
-    S[Source plugin] -->|produces| A[Asset]
-    A -->|member of| C[Collection]
-    A -->|has immutable| AV[Asset Version]
-    AV -.->|derived from| AV
-    OR[Operation Run] -->|consumes| AV
-    OR -->|produces| AV
-    OR -->|records| L[Lineage edges]
-    X[Selector] -->|matches| A
-    X -->|defines membership| C
-    P[Processing Policy] -->|declares| G[Processing Goal]
-    P -->|matches with| X
-    G -->|dispatches eligible| OR
-    OR -->|satisfies| G
-    A -->|published by| K[Sink plugin]
-    A -->|carries| F[Facets]
-```
-
 **Asset** — one logical file. Stable opaque identity, independent of path, so the system reorganising a
 tree never destroys its own references. Carries a small core-owned envelope (`id`, `kind`, `name`) plus
 typed [facets](#core-and-domain-packs), and one or more immutable `AssetVersion` records.
@@ -105,6 +88,27 @@ opaquely stuck. → [ADR-006](../decisions/ADR-006-rule-engine-deferral.md)
 addressed, input and output versions, params, idempotency key, side-effect state, status, and logs.
 Re-run eligibility follows the Operator's side-effect class; an ambiguous external publish is not blindly
 replayed. → [ADR-006](../decisions/ADR-006-rule-engine-deferral.md)
+
+How they relate (reference, not a flow):
+
+```mermaid
+graph TD
+    S[Source plugin] -->|produces| A[Asset]
+    A -->|member of| C[Collection]
+    A -->|has immutable| AV[Asset Version]
+    AV -.->|derived from| AV
+    OR[Operation Run] -->|consumes| AV
+    OR -->|produces| AV
+    OR -->|records| L[Lineage edges]
+    X[Selector] -->|matches| A
+    X -->|defines membership| C
+    P[Processing Policy] -->|declares| G[Processing Goal]
+    P -->|matches with| X
+    G -->|dispatches eligible| OR
+    OR -->|satisfies| G
+    A -->|published by| K[Sink plugin]
+    A -->|carries| F[Facets]
+```
 
 ## Plugin model
 
@@ -161,7 +165,7 @@ rest are accepted.
 **ADR-001 and ADR-007 are coupled** — the execution profile says how code runs; grants and
 `AssetContext` say what it may do. Neither is complete without the other.
 
-## Key design decisions
+## Design facts
 
 Settled calls that don't warrant an ADR — no significant alternative to weigh, or cheap to reverse.
 Anything with real trade-offs is an ADR (table above); product scope lives in RFC #213. If a fact grows
@@ -186,15 +190,3 @@ tracked as sub-issues under [#213](https://github.com/sidereal-io/sidereal/issue
 
 Decision in [ADR-010](../decisions/ADR-010-migration-strategy.md); the cutover gate — checklist,
 compatibility breaks, filesystem-safety invariants, and rollback — in **[migration.md](migration.md)**.
-
-## What this document is not
-
-- **Not a plan.** Milestones are sub-issues under #213.
-- **Not fully accepted.** #213 is `status/ready`, but some ADRs are still Proposed — the
-  [decision index](#architecture-decisions) is canonical, and anything it marks Proposed is a leaning.
-- **Not a v0.10.x reference.** The authoritative record of current behaviour is the
-  [analysis package](https://github.com/sidereal-io/sidereal-analysis).
-
-**Changing it:** an architectural change goes through an ADR in [`docs/decisions/`](../decisions/), then
-this map is updated in the same PR. Resolving an open ADR means filling in its Decision, flipping its
-status, and updating the [decision index](#architecture-decisions) above.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,9 +4,9 @@
 
 > **Why this lives in the repo.** Feature designs live in issue bodies; this is different. It is the
 > standing answer to "what is this system and where is it going," and it must outlive the issue that
-> produced it. #213 is the *proposal*; this is the *reference*. Seven of the eight M0 ADRs are
-> accepted; only [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend continuity) is still
-> Proposed, so the frontend approach here is a leaning, not a commitment.
+> produced it. #213 is the *proposal*; this is the *reference*. Every M0 ADR is accepted except
+> [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend continuity), so the frontend approach
+> here is a leaning, not a commitment.
 
 This document is a **map**: the north star, a glossary of the load-bearing concepts, and pointers to
 the ADRs and specs that own each decision. It does not restate them — [`docs/decisions/`](../decisions/)
@@ -32,9 +32,9 @@ What this model **cannot** express, and v2 must:
 ## Where we're going
 
 **Product:** an astrophotography system that manages photos at *every* stage — calibration frames, raw
-lights, stacked results, annotated finals. **Codebase:** a Rust backend, a plugin system for
-input/output formats and operations, and a TypeScript/React frontend. Three commitments shape
-everything below:
+lights, stacked results, annotated finals. **Codebase:** a
+[Rust backend](../decisions/ADR-009-backend-language.md), a plugin system for input/output formats and
+operations, and a TypeScript/React frontend. Three commitments shape everything below:
 
 1. **Sidereal becomes the system of record for files on disk** — it renames, moves, and organises them.
 2. **Sidereal does not do the math.** Calibration, registration, and integration stay in
@@ -81,8 +81,7 @@ at versions, never at the mutable Asset. → [ADR-003](../decisions/ADR-003-stor
 
 **Collection** — a generic grouping (a session, an album). Membership is explicit or defined by a
 Selector. Processing binds an immutable membership snapshot, so a Collection changing underneath a run
-cannot alter its inputs. Derived values (integration totals) are always computed, never denormalised
-onto a row that can drift.
+cannot alter its inputs.
 
 **Selector** — the shared, deterministic predicate for "what does this apply to." A bounded language
 (boolean composition + existence/equality/set/typed-facet comparisons) over `kind`, source, facets, and
@@ -154,9 +153,26 @@ rationale. All are M0 work. **ADR-005 is still open**; the rest are accepted.
 | [006](../decisions/ADR-006-rule-engine-deferral.md) | Declarative processing & policy deferral | Accepted |
 | [007](../decisions/ADR-007-security-and-plugin-trust.md) | Security & plugin trust | Accepted |
 | [008](../decisions/ADR-008-facet-schema-and-write-authority.md) | Metadata envelope, facets & write authority | Accepted |
+| [009](../decisions/ADR-009-backend-language.md) | Backend language & runtime | Accepted (Rust) |
+| [010](../decisions/ADR-010-migration-strategy.md) | Migration strategy | Accepted (clean break + one-way importer) |
 
 **ADR-001 and ADR-007 are coupled** — the execution profile says how code runs; grants and
 `AssetContext` say what it may do. Neither is complete without the other.
+
+## Key design decisions
+
+Settled calls that don't warrant an ADR — no significant alternative to weigh, or cheap to reverse.
+Anything with real trade-offs is an ADR (table above); product scope lives in RFC #213. If a fact grows
+a contested *why*, promote it to an ADR and it becomes a row above.
+
+- **The frontend stays TypeScript/React** through the backend's move to Rust — the deliberate continuity
+  that keeps current contributors productive. (Evolve-vs-start-fresh is
+  [ADR-005](../decisions/ADR-005-frontend-continuity.md)'s separate, still-open call.)
+- **Derived values are always computed, never stored** — integration totals and the like are recomputed
+  from member assets and their facets, never denormalised onto a row that can drift (a v0.10.x mistake
+  we don't repeat).
+- **A plugin may implement multiple capabilities** — Immich is both a Source and a Sink; the
+  registration mechanism is one.
 
 ## Milestone map
 
@@ -177,7 +193,7 @@ graph LR
 
 | Milestone | Exit criterion |
 |---|---|
-| **M0** Contracts & scaffolding | Eight ADRs accepted; Rhai/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
+| **M0** Contracts & scaffolding | All M0 ADRs accepted (ADR-005 the last open one), including security and plugin grants; Rhai/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
 | **M1** Core spine & first plugins | Drop a file in a watched folder → it appears in the UI with extracted metadata, entirely through plugin contracts |
 | **M2** Operator engine & API v0.1 | Operator API, `AssetContext`, selector contract, side-effect protocol published; four built-ins consume it, ≥2 through Rhai; durable goals, reconciliation, and recovery-after-missed-events proven |
 | **M3** Astro domain pack | Source facets + built-in policy converge a full session — lights + darks + flats → grouped, masters matched, lineage recorded |
@@ -192,15 +208,16 @@ frontend contributors productive through a backend language switch.
 
 ## Migration & cutover
 
-A **clean break with a one-way importer**, gated on a non-negotiable feature set. The full cutover gate —
-the required-before-cutover checklist, compatibility breaks, filesystem-safety invariants, and rollback —
+A **clean break with a one-way importer**, gated on a non-negotiable feature set
+([ADR-010](../decisions/ADR-010-migration-strategy.md)). The full cutover gate — the
+required-before-cutover checklist, compatibility breaks, filesystem-safety invariants, and rollback —
 lives in **[migration.md](migration.md)**.
 
 ## What this document is not
 
 - **Not a plan.** Milestones are sub-issues under #213.
-- **Not fully accepted.** #213 is `status/ready`; ADR-005 is still Proposed, so the frontend approach is
-  a leaning.
+- **Not fully accepted.** #213 is `status/ready`; every M0 ADR is accepted except ADR-005 (frontend
+  continuity), so the frontend approach is a leaning.
 - **Not a v0.10.x reference.** The authoritative record of current behaviour is the
   [analysis package](https://github.com/sidereal-io/sidereal-analysis).
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -208,10 +208,8 @@ frontend contributors productive through a backend language switch.
 
 ## Migration & cutover
 
-A **clean break with a one-way importer**, gated on a non-negotiable feature set
-([ADR-010](../decisions/ADR-010-migration-strategy.md)). The full cutover gate — the
-required-before-cutover checklist, compatibility breaks, filesystem-safety invariants, and rollback —
-lives in **[migration.md](migration.md)**.
+Decision in [ADR-010](../decisions/ADR-010-migration-strategy.md); the cutover gate — checklist,
+compatibility breaks, filesystem-safety invariants, and rollback — in **[migration.md](migration.md)**.
 
 ## What this document is not
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -338,33 +338,35 @@ facets, so `kind = light` requires one set of outcomes and `kind = dark` another
 changes. Calibration-master matching — "find a master dark for this camera at -10 °C, gain 100,
 300 s, bin 1×1" — is a facet query, not bespoke schema.
 
-**What this requires of the storage engine** (input to ADR-004, which is otherwise open):
+**What this requires of the storage engine** (input to ADR-004):
 
 - Indexed lookup on semi-structured facet values.
 - Recursive traversal for lineage graphs ("everything derived from this master, transitively").
-- No hard dependency on a server database for single-user installs.
+- A zero-config single-user install experience.
 
-SQLite (JSON1 + recursive CTEs) and PostgreSQL both satisfy all three, so the architecture does not
-force the choice. ADR-004 picks on other grounds.
+SQLite (JSON1 + recursive CTEs) and PostgreSQL both satisfy the first two. **ADR-004 is accepted as
+PostgreSQL-only** (JSONB + GIN for facets, best recursive-CTE performance, one dialect); the
+zero-config requirement is met at the packaging layer — an all-in-one image / compose bundle — rather
+than by a serverless engine.
 
 ---
 
 ## Open seams
 
 Points where a reader would otherwise assume something is settled. Each has an ADR; all are M0 work.
-ADR-002 and ADR-006 are accepted; the rest record a leaning and fill in their Decision section when
-approved.
+All except ADR-005 are now **accepted**; ADR-005 remains Proposed, gated on a contributor conversation
+and a green E2E baseline before its Decision is filled in.
 
 | # | Seam | Affects | Status / leaning |
 |---|---|---|---|
-| [ADR-001](../decisions/ADR-001-plugin-boundary.md) | **Plugin contract and execution profiles** — built-in Rust · embedded Rhai · external provider | Installation, capability isolation, performance, non-Rust authorship | Capability-oriented hybrid |
+| [ADR-001](../decisions/ADR-001-plugin-boundary.md) | **Plugin contract and execution profiles** — built-in Rust · embedded Rhai · external provider | Installation, capability isolation, performance, non-Rust authorship | **Accepted** — capability-oriented hybrid, one semantic contract across three profiles; Rhai initial script engine (M0 spike, Rune/Lua fallback); WASM deferred |
 | [ADR-002](../decisions/ADR-002-core-domain-pack-split.md) | **Core / domain-pack seam** — where exactly it falls, and whether packs are compiled in or loaded | How much of the astro feature set is separable work | **Accepted** — astro compiled in as `packs/astro` coding against `plugin-abi` (Option A; dynamic whole-pack swap deferred); session a core concept with pack vocabulary; equipment pack-owned; frontend API + facet schemas only (no dynamic frontend ABI in v2.0) |
-| [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md) | **Storage layout and identity** — stable Assets, immutable AssetVersions, on-disk tree | Lineage integrity, dedup, revision retention, rename cost | Stable Asset plus immutable versions |
-| [ADR-004](../decisions/ADR-004-database-engine-and-schema.md) | **Database engine and schema strategy** | Deployment story, facet indexing, migration tooling | Keep SQLite-default / Postgres-optional |
-| [ADR-005](../decisions/ADR-005-frontend-continuity.md) | **Frontend continuity** — evolve the existing React app against the new API, or start fresh | Whether M5 begins from a working codebase; contributor continuity | None stated |
+| [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md) | **Storage layout and identity** — stable Assets, immutable AssetVersions, on-disk tree | Lineage integrity, dedup, revision retention, rename cost | **Accepted** — Option C: stable Asset + immutable AssetVersion; `current_version_id` pointer (computed `isLatest`); `version_seq`/label navigation; optimistic-concurrency advance; on-disk tree still to settle before M1 |
+| [ADR-004](../decisions/ADR-004-database-engine-and-schema.md) | **Database engine and schema strategy** | Deployment story, facet indexing, migration tooling | **Accepted** — **PostgreSQL-only** (reverses the SQLite-default leaning); facets in JSONB + GIN; `sqlx`; forward-only migrations; zero-config preserved via all-in-one image / compose bundle |
+| [ADR-005](../decisions/ADR-005-frontend-continuity.md) | **Frontend continuity** — evolve the existing React app against the new API, or start fresh | Whether M5 begins from a working codebase; contributor continuity | _Proposed_ — leaning Option C (new shell, port components), gated on the contributor conversation + a green v0.10.x E2E baseline |
 | [ADR-006](../decisions/ADR-006-rule-engine-deferral.md) | **Declarative processing, selectors, and policy deferral** — match subjects and reconcile desired outcomes; defer user-authored policy rules | Applicability, Collection membership, and whether M2 needs workflows or convergent goal processing | **Accepted** — shared selectors and reconciliation in M2; policy editor in M7+ |
-| [ADR-007](../decisions/ADR-007-security-and-plugin-trust.md) | **Security and plugin trust** | Authentication, CORS/CSRF, grants, provider trust, secrets | Built-in single-user auth and explicit grants |
-| [ADR-008](../decisions/ADR-008-facet-schema-and-write-authority.md) | **Metadata envelope, facets, and write authority** | Canonical placement, selector portability, cross-plugin interoperability, and schema evolution | Small core envelope plus typed, scoped facets |
+| [ADR-007](../decisions/ADR-007-security-and-plugin-trust.md) | **Security and plugin trust** | Authentication, CORS/CSRF, grants, provider trust, secrets | **Accepted** — Option B: built-in single-user auth, CSRF, deny-by-default CORS, explicit plugin grants; multi-user RBAC deferred |
+| [ADR-008](../decisions/ADR-008-facet-schema-and-write-authority.md) | **Metadata envelope, facets, and write authority** | Canonical placement, selector portability, cross-plugin interoperability, and schema evolution | **Accepted** — small core envelope + facets; Option C exclusive schema owner with producer grants; mutable-facet audit history deferred post-cutover |
 
 **ADR-001 and ADR-007 are coupled.** The execution profile says how code runs; grants and
 `AssetContext` say what it is allowed to do. Neither decision is complete without the other.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,9 +4,9 @@
 
 > **Why this lives in the repo.** Feature designs live in issue bodies; this is different. It is the
 > standing answer to "what is this system and where is it going," and it must outlive the issue that
-> produced it. #213 is the *proposal*; this is the *reference*. Every M0 ADR is accepted except
-> [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend continuity), so the frontend approach
-> here is a leaning, not a commitment.
+> produced it. #213 is the *proposal*; this is the *reference*. Where the [decision
+> index](#architecture-decisions) below marks an ADR **Proposed**, the corresponding approach here is a
+> leaning, not a commitment.
 
 This document is a **map**: the north star, a glossary of the load-bearing concepts, and pointers to
 the ADRs and specs that own each decision. It does not restate them — [`docs/decisions/`](../decisions/)
@@ -48,7 +48,7 @@ astro product.
 
 ## Core concepts
 
-Six load-bearing additions that do not exist today; everything else in v2 is a consequence of them.
+Seven load-bearing additions that do not exist today; everything else in v2 is a consequence of them.
 
 ```mermaid
 graph TD
@@ -118,7 +118,7 @@ Source and Sink).
 | **Sink** | Publishes assets outward | Immich · static gallery · Astrobin · S3 |
 
 All profiles implement the same semantic contract and conformance suite; only the transport differs
-(built-in Rust, embedded Rhai script, or external provider), and every profile receives the same
+(built-in Rust, embedded script, or external provider), and every profile receives the same
 capability-limited `AssetContext` — no filesystem back door. The full contract is in
 **[plugins.md](plugins.md)**; the execution profiles and trust model are
 [ADR-001](../decisions/ADR-001-plugin-boundary.md) and
@@ -141,7 +141,8 @@ facet query rather than bespoke schema. → [ADR-008](../decisions/ADR-008-facet
 ## Architecture decisions
 
 Each decision has an ADR in [`docs/decisions/`](../decisions/) with the full context, options, and
-rationale. All are M0 work. **ADR-005 is still open**; the rest are accepted.
+rationale. Two remain **Proposed** — ADR-005 (frontend) and ADR-011 (storage tree, which gates M1); the
+rest are accepted.
 
 | ADR | Decision | Status |
 |---|---|---|
@@ -155,6 +156,7 @@ rationale. All are M0 work. **ADR-005 is still open**; the rest are accepted.
 | [008](../decisions/ADR-008-facet-schema-and-write-authority.md) | Metadata envelope, facets & write authority | Accepted |
 | [009](../decisions/ADR-009-backend-language.md) | Backend language & runtime | Accepted (Rust) |
 | [010](../decisions/ADR-010-migration-strategy.md) | Migration strategy | Accepted (clean break + one-way importer) |
+| [011](../decisions/ADR-011-storage-tree-layout.md) | Storage tree layout & cross-filesystem moves | **Proposed** — split from ADR-003; gates M1 |
 
 **ADR-001 and ADR-007 are coupled** — the execution profile says how code runs; grants and
 `AssetContext` say what it may do. Neither is complete without the other.
@@ -188,11 +190,11 @@ compatibility breaks, filesystem-safety invariants, and rollback — in **[migra
 ## What this document is not
 
 - **Not a plan.** Milestones are sub-issues under #213.
-- **Not fully accepted.** #213 is `status/ready`; every M0 ADR is accepted except ADR-005 (frontend
-  continuity), so the frontend approach is a leaning.
+- **Not fully accepted.** #213 is `status/ready`, but some ADRs are still Proposed — the
+  [decision index](#architecture-decisions) is canonical, and anything it marks Proposed is a leaning.
 - **Not a v0.10.x reference.** The authoritative record of current behaviour is the
   [analysis package](https://github.com/sidereal-io/sidereal-analysis).
 
 **Changing it:** an architectural change goes through an ADR in [`docs/decisions/`](../decisions/), then
-this map is updated in the same PR. Resolving ADR-005 means filling in its Decision, flipping its status,
-and updating the [decision index](#architecture-decisions) above.
+this map is updated in the same PR. Resolving an open ADR means filling in its Decision, flipping its
+status, and updating the [decision index](#architecture-decisions) above.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,6 +1,6 @@
 # Sidereal Architecture
 
-**Status:** Proposed · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) (`status/ready`) · **Last updated:** 2026-08-04
+**Status:** Proposed · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) (`status/ready`) · **Last updated:** 2026-08-18
 
 > **Why this lives in the repo.** The [Feature & Bug Workflow](../../CLAUDE.md) says designs live in the
 > issue body, not the repo tree. That rule is right for features — a feature design is scaffolding
@@ -9,9 +9,9 @@
 > Issue #213 is the *proposal*; this is the *reference*. Keep them in sync while #213 is open; after
 > it closes, this file is the surviving record.
 >
-> **#213 has passed its design approval gate and is `status/ready`; the individual ADRs have not.**
-> Seven of the eight still carry an empty Decision section and are resolved during M0. Treat any
-> statement marked ◇ or listed under [Open seams](#open-seams) as a leaning, not a commitment.
+> **#213 has passed its design approval gate and is `status/ready`.** Seven of the eight M0 ADRs are
+> now accepted; only [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend continuity)
+> remains Proposed, so the frontend approach below is a leaning, not a commitment.
 
 ## Contents
 
@@ -20,7 +20,7 @@
 - [Core concepts](#core-concepts) — Asset · Collection · Selector · Lineage · Processing Goal · Operation Run
 - [Plugin model](#plugin-model) — the summary; full contract in [plugins.md](plugins.md)
 - [Core and domain packs](#core-and-domain-packs) — the facet mechanism
-- [Open seams](#open-seams) — what is deliberately undecided
+- [Architecture decisions](#architecture-decisions) — the ADR index
 - [Milestone map](#milestone-map) — M0 → M7
 
 ---
@@ -151,9 +151,9 @@ identity were path-derived, the system reorganising a tree would destroy its own
 contributed by the astro domain pack, not core vocabulary. See
 [Core and domain packs](#core-and-domain-packs).
 
-> ◇ **Proposed — [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md):** stable
+> **[ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md) — accepted:** stable
 > surrogate Asset identity plus immutable content-addressed AssetVersions. The exact on-disk tree and
-> retention policy remain part of the decision.
+> retention policy are still to be settled before M1.
 
 ### Collection
 
@@ -351,22 +351,22 @@ than by a serverless engine.
 
 ---
 
-## Open seams
+## Architecture decisions
 
-Points where a reader would otherwise assume something is settled. Each has an ADR; all are M0 work.
-All except ADR-005 are now **accepted**; ADR-005 remains Proposed, gated on a contributor conversation
-and a green E2E baseline before its Decision is filled in.
+Every architectural decision has an ADR in [`docs/decisions/`](../decisions/) — read those for the
+full context, options, and rationale. All are M0 work. **ADR-005 is still open**; the rest are
+accepted.
 
-| # | Seam | Affects | Status / leaning |
-|---|---|---|---|
-| [ADR-001](../decisions/ADR-001-plugin-boundary.md) | **Plugin contract and execution profiles** — built-in Rust · embedded Rhai · external provider | Installation, capability isolation, performance, non-Rust authorship | **Accepted** — capability-oriented hybrid, one semantic contract across three profiles; Rhai initial script engine (M0 spike, Rune/Lua fallback); WASM deferred |
-| [ADR-002](../decisions/ADR-002-core-domain-pack-split.md) | **Core / domain-pack seam** — where exactly it falls, and whether packs are compiled in or loaded | How much of the astro feature set is separable work | **Accepted** — astro compiled in as `packs/astro` coding against `plugin-abi` (Option A; dynamic whole-pack swap deferred); session a core concept with pack vocabulary; equipment pack-owned; frontend API + facet schemas only (no dynamic frontend ABI in v2.0) |
-| [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md) | **Storage layout and identity** — stable Assets, immutable AssetVersions, on-disk tree | Lineage integrity, dedup, revision retention, rename cost | **Accepted** — Option C: stable Asset + immutable AssetVersion; `current_version_id` pointer (computed `isLatest`); `version_seq`/label navigation; optimistic-concurrency advance; on-disk tree still to settle before M1 |
-| [ADR-004](../decisions/ADR-004-database-engine-and-schema.md) | **Database engine and schema strategy** | Deployment story, facet indexing, migration tooling | **Accepted** — **PostgreSQL-only** (reverses the SQLite-default leaning); facets in JSONB + GIN; `sqlx`; forward-only migrations; zero-config preserved via all-in-one image / compose bundle |
-| [ADR-005](../decisions/ADR-005-frontend-continuity.md) | **Frontend continuity** — evolve the existing React app against the new API, or start fresh | Whether M5 begins from a working codebase; contributor continuity | _Proposed_ — leaning Option C (new shell, port components), gated on the contributor conversation + a green v0.10.x E2E baseline |
-| [ADR-006](../decisions/ADR-006-rule-engine-deferral.md) | **Declarative processing, selectors, and policy deferral** — match subjects and reconcile desired outcomes; defer user-authored policy rules | Applicability, Collection membership, and whether M2 needs workflows or convergent goal processing | **Accepted** — shared selectors and reconciliation in M2; policy editor in M7+ |
-| [ADR-007](../decisions/ADR-007-security-and-plugin-trust.md) | **Security and plugin trust** | Authentication, CORS/CSRF, grants, provider trust, secrets | **Accepted** — Option B: built-in single-user auth, CSRF, deny-by-default CORS, explicit plugin grants; multi-user RBAC deferred |
-| [ADR-008](../decisions/ADR-008-facet-schema-and-write-authority.md) | **Metadata envelope, facets, and write authority** | Canonical placement, selector portability, cross-plugin interoperability, and schema evolution | **Accepted** — small core envelope + facets; Option C exclusive schema owner with producer grants; mutable-facet audit history deferred post-cutover |
+| ADR | Decision | Status |
+|---|---|---|
+| [001](../decisions/ADR-001-plugin-boundary.md) | Plugin contract & execution profiles | Accepted |
+| [002](../decisions/ADR-002-core-domain-pack-split.md) | Core / domain-pack seam | Accepted |
+| [003](../decisions/ADR-003-storage-layout-and-asset-identity.md) | Storage layout & asset identity | Accepted |
+| [004](../decisions/ADR-004-database-engine-and-schema.md) | Database engine & schema strategy | Accepted |
+| [005](../decisions/ADR-005-frontend-continuity.md) | Frontend continuity | **Proposed** — gated on the contributor conversation + a green v0.10.x E2E baseline |
+| [006](../decisions/ADR-006-rule-engine-deferral.md) | Declarative processing & policy deferral | Accepted |
+| [007](../decisions/ADR-007-security-and-plugin-trust.md) | Security & plugin trust | Accepted |
+| [008](../decisions/ADR-008-facet-schema-and-write-authority.md) | Metadata envelope, facets & write authority | Accepted |
 
 **ADR-001 and ADR-007 are coupled.** The execution profile says how code runs; grants and
 `AssetContext` say what it is allowed to do. Neither decision is complete without the other.
@@ -478,14 +478,15 @@ before import. After cutover, rollback restores that backup. The importer remain
 ## What this document is not
 
 - **Not a plan.** Milestones are sub-issues under #213; the plan lives there.
-- **Not fully accepted.** #213 is `status/ready`, but six of the eight ADRs are still Proposed.
-  Until each Decision section is filled in, the seams they cover describe a leaning.
+- **Not fully accepted.** #213 is `status/ready`, and seven of the eight M0 ADRs are accepted;
+  [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend continuity) is still Proposed.
+  Until its Decision is filled in, the frontend approach is a leaning.
 - **Not a v0.10.x reference.** [Where we are](#where-we-are) is a summary; the authoritative record of
   current behaviour is the [analysis package](https://github.com/sidereal-io/sidereal-analysis).
 
 ### Changing it
 
 Architectural changes go through an ADR in [`docs/decisions/`](../decisions/), then this document is
-updated in the same PR. If you are resolving one of the [open seams](#open-seams), fill in the stub
-ADR's Decision section, flip its status to Accepted, and replace the ◇ marker here with what was
-decided.
+updated in the same PR. If you are resolving the remaining open ADR, fill in its Decision section,
+flip its status to Accepted, and update the [decision index](#architecture-decisions) and any
+provisional statement it settles.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -174,37 +174,11 @@ a contested *why*, promote it to an ADR and it becomes a row above.
 - **A plugin may implement multiple capabilities** — Immich is both a Source and a Sink; the
   registration mechanism is one.
 
-## Milestone map
+## Build shape
 
-Critical path is **M0 → M1 → M2**. If the plugin interface is wrong, we find out at M2 rather than M6.
-
-```mermaid
-graph LR
-    M0[M0 Contracts<br/>& scaffolding] --> M1[M1 Core spine<br/>& first plugins]
-    M1 --> M2[M2 Operator engine<br/>& Operator API v0.1]
-    M2 --> M3[M3 Astro<br/>domain pack]
-    M2 --> M4[M4 Sources, sinks<br/>& importer]
-    M1 -.parallel.-> M5[M5 Frontend<br/>parity]
-    M3 --> M6[M6 Cutover]
-    M4 --> M6
-    M5 --> M6
-    M6 --> M7[M7+ North star<br/>proper]
-```
-
-| Milestone | Exit criterion |
-|---|---|
-| **M0** Contracts & scaffolding | All M0 ADRs accepted (ADR-005 the last open one), including security and plugin grants; Rhai/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
-| **M1** Core spine & first plugins | Drop a file in a watched folder → it appears in the UI with extracted metadata, entirely through plugin contracts |
-| **M2** Operator engine & API v0.1 | Operator API, `AssetContext`, selector contract, side-effect protocol published; four built-ins consume it, ≥2 through Rhai; durable goals, reconciliation, and recovery-after-missed-events proven |
-| **M3** Astro domain pack | Source facets + built-in policy converge a full session — lights + darks + flats → grouped, masters matched, lineage recorded |
-| **M4** Sources, sinks & importer | A real v0.10.x install imports cleanly and reports what didn't map |
-| **M5** Frontend parity | Every non-negotiable cutover item green (starts at M1, parallel to backend) |
-| **M6** Cutover | Docker parity, migration guide, beta with real users, `v2.0.0` |
-| **M7+** North star proper | User-authored policies · Siril/PixInsight · AI plugins · general-media pack exploration |
-
-**M5 starts at M1**, not last — the frontend is a separate workstream against the HTTP API and stays
-TypeScript/React. This is the single most important scheduling decision in the plan: it keeps existing
-frontend contributors productive through a backend language switch.
+Critical path is **M0 → M1 → M2**; if the plugin interface is wrong, we find out at M2 rather than M6.
+The milestone map, exit criteria, and parallelism are in **[roadmap.md](roadmap.md)**; milestones are
+tracked as sub-issues under [#213](https://github.com/sidereal-io/sidereal/issues/213).
 
 ## Migration & cutover
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,105 +1,54 @@
 # Sidereal Architecture
 
-**Status:** Proposed · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) (`status/ready`) · **Last updated:** 2026-08-18
+**Status:** Proposed · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) (`status/ready`) · **Last updated:** 2026-08-19
 
-> **Why this lives in the repo.** The [Feature & Bug Workflow](../../CLAUDE.md) says designs live in the
-> issue body, not the repo tree. That rule is right for features — a feature design is scaffolding
-> that stops mattering once the code ships. This document is different: it is the standing answer to
-> "what is this system and where is it going," and it needs to outlive the issue that produced it.
-> Issue #213 is the *proposal*; this is the *reference*. Keep them in sync while #213 is open; after
-> it closes, this file is the surviving record.
->
-> **#213 has passed its design approval gate and is `status/ready`.** Seven of the eight M0 ADRs are
-> now accepted; only [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend continuity)
-> remains Proposed, so the frontend approach below is a leaning, not a commitment.
+> **Why this lives in the repo.** Feature designs live in issue bodies; this is different. It is the
+> standing answer to "what is this system and where is it going," and it must outlive the issue that
+> produced it. #213 is the *proposal*; this is the *reference*. Seven of the eight M0 ADRs are
+> accepted; only [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend continuity) is still
+> Proposed, so the frontend approach here is a leaning, not a commitment.
 
-## Contents
-
-- [Where we are](#where-we-are) — v0.10.x, honestly
-- [Where we're going](#where-were-going) — the north star
-- [Core concepts](#core-concepts) — Asset · Collection · Selector · Lineage · Processing Goal · Operation Run
-- [Plugin model](#plugin-model) — the summary; full contract in [plugins.md](plugins.md)
-- [Core and domain packs](#core-and-domain-packs) — the facet mechanism
-- [Architecture decisions](#architecture-decisions) — the ADR index
-- [Milestone map](#milestone-map) — M0 → M7
-
----
+This document is a **map**: the north star, a glossary of the load-bearing concepts, and pointers to
+the ADRs and specs that own each decision. It does not restate them — [`docs/decisions/`](../decisions/)
+is the source of truth for *why* each call was made.
 
 ## Where we are
 
-Sidereal v0.10.x is **a viewer over an Immich library**. This is a fair description, not a
-disparaging one — it does that job well, and it is the shipped, supported product until cutover.
+Sidereal v0.10.x is **a viewer over an Immich library** — and a good one, supported until cutover. Its
+data model has exactly one asset concept: an `Image`, synced read-only from Immich, already finished,
+with plate-solve results attached. A "target" is not an entity; it is `GROUP BY targetName` computed at
+read time. The full current behaviour is catalogued in the
+[analysis package](https://github.com/sidereal-io/sidereal-analysis) (private) — an inventory of what
+not to forget, not a compatibility contract.
 
-The data model has exactly one asset concept: an `Image`, synced from Immich, already finished,
-with plate-solve results attached. Immich is the source of truth; Sidereal mirrors it read-only.
-An asset disappearing from Immich deletes the Sidereal record.
+What this model **cannot** express, and v2 must:
 
-Everything else in the model hangs off that single `Image`:
-
-```
-ImageSource (local|url|immich) ──ingests──▶ Image
-                                             ├── 1..* PlateSolvingJob
-                                             ├── 1..* AcquisitionEntry ──▶ Equipment (filter)
-                                             ├── *..* Equipment (link + per-image settings)
-                                             └── targetName ┄soft ref┄▶ CatalogObject
-EquipmentGroup *..* Equipment ──apply──▶ Image links
-UserTarget ┄soft ref┄▶ CatalogObject
-```
-
-A "target" is not an entity — it is `GROUP BY targetName` computed at read time, enriched from the
-OpenNGC catalog when the name happens to match. Integration totals are derived by recomputing
-summary fields on the `Image` row whenever acquisitions or equipment links change.
-
-The full externally-observable behaviour is catalogued in the
-[behavioural specification package](https://github.com/sidereal-io/sidereal-analysis) (private).
-Treat it as **an inventory of what not to forget**, not as a compatibility contract — see
-[Migration](#migration-and-cutover).
-
-### What this model cannot express
-
-Astrophotography produces three things the current model has no shape for:
-
-- **Calibration frames in sets** — 50 darks at a given temperature, gain, and exposure; masters
-  derived from them and reused across months of sessions.
+- **Calibration frames in sets** — 50 darks at a temperature/gain/exposure; masters reused for months.
 - **Lights by the hundreds per session**, as FITS/XISF, long before anything is presentable.
 - **Stacked results with provenance** — "these 187 lights, this master dark, this master flat,
-  integrated on this date."
-
-The highest-value question a user can ask — *"what did I use this master dark on, and is it still
-valid for this camera at this temperature?"* — is unanswerable today, because lineage is not
-modelled at all.
-
----
+  integrated on this date." Lineage is not modelled at all today; that gap is why the rewrite is a
+  rewrite.
 
 ## Where we're going
 
-**Product:** an astrophotography processing system that manages photos at *all* stages of the hobby —
-calibration frames, raw lights, stacked results, annotated finals.
+**Product:** an astrophotography system that manages photos at *every* stage — calibration frames, raw
+lights, stacked results, annotated finals. **Codebase:** a Rust backend, a plugin system for
+input/output formats and operations, and a TypeScript/React frontend. Three commitments shape
+everything below:
 
-**Codebase:** a rewrite with a Rust backend, a plugin system for input/output formats and operations,
-and a web frontend for managing assets, processing, and metadata.
-
-Three commitments shape everything below:
-
-1. **Sidereal becomes the system of record for files on disk.** It renames, moves, and organises
-   them. Today it mirrors someone else's tree; in v2 it owns one.
+1. **Sidereal becomes the system of record for files on disk** — it renames, moves, and organises them.
 2. **Sidereal does not do the math.** Calibration, registration, and integration stay in
-   Siril / PixInsight / APP. Sidereal may invoke them through plugins. It does not
-   reimplement them.
-3. **Every processing action is a plugin, including the built-in ones.** This is what keeps the
-   plugin interface honest — see [plugins.md](plugins.md).
+   Siril/PixInsight/APP, invoked through plugins. It does not reimplement them.
+3. **Every processing action is a plugin, including the built-in ones** — this is what keeps the plugin
+   interface honest.
 
-**Not an Immich replacement.** The core is built so it doesn't *forbid* general media management,
-but that future is explicitly unfunded. Immich's hard parts — ML at scale, mobile apps with
-background upload, multi-user sharing — are not needed for the astro product, and any one of them
-would eat a year.
-
----
+**Not an Immich replacement.** The core does not *forbid* general media management, but that future is
+unfunded — Immich's hard parts (ML at scale, mobile apps, multi-user sharing) are not needed for the
+astro product.
 
 ## Core concepts
 
-Six concepts that do not exist today. These are the load-bearing additions; everything else in v2
-is a consequence of them.
+Six load-bearing additions that do not exist today; everything else in v2 is a consequence of them.
 
 ```mermaid
 graph TD
@@ -110,273 +59,108 @@ graph TD
     OR[Operation Run] -->|consumes| AV
     OR -->|produces| AV
     OR -->|records| L[Lineage edges]
-    E["State-change event"] -->|prompts| R[Reconciler]
     X[Selector] -->|matches| A
     X -->|defines membership| C
     P[Processing Policy] -->|declares| G[Processing Goal]
     P -->|matches with| X
-    R -->|reevaluates| G
     G -->|dispatches eligible| OR
     OR -->|satisfies| G
-    L -.->|between| AV
     A -->|published by| K[Sink plugin]
     A -->|carries| F[Facets]
 ```
 
-### Asset
+**Asset** — one logical file. Stable opaque identity, independent of path, so the system reorganising a
+tree never destroys its own references. Carries a small core-owned envelope (`id`, `kind`, `name`) plus
+typed [facets](#core-and-domain-packs), and one or more immutable `AssetVersion` records.
+→ [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md),
+[ADR-008](../decisions/ADR-008-facet-schema-and-write-authority.md)
 
-One logical file managed by Sidereal. It has a stable opaque identity, a path, a `kind`, typed
-metadata (as [facets](#core-and-domain-packs)), and one or more immutable `AssetVersion` records.
-Each version identifies an exact byte state by content hash.
+**AssetVersion** — an exact byte state, content-addressed by hash. A rename/move is a path event and
+creates no version; any byte change creates a new immutable version. Lineage and Operation Runs point
+at versions, never at the mutable Asset. → [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md)
 
-Every Asset has a small core-owned **metadata envelope**:
+**Collection** — a generic grouping (a session, an album). Membership is explicit or defined by a
+Selector. Processing binds an immutable membership snapshot, so a Collection changing underneath a run
+cannot alter its inputs. Derived values (integration totals) are always computed, never denormalised
+onto a row that can drift.
 
-| Field | Meaning |
-|---|---|
-| `id` | Stable opaque identity; never derived from name or path. |
-| `kind` | Pack-defined normalized discriminator such as `astro.light` or `astro.stacked`. |
-| `name` | Mutable human-facing display name; not required to be unique and not the filesystem path. |
+**Selector** — the shared, deterministic predicate for "what does this apply to." A bounded language
+(boolean composition + existence/equality/set/typed-facet comparisons) over `kind`, source, facets, and
+membership — data, not plugin code, so matching stays indexable and explainable. One primitive answers
+three questions: which goals apply to a subject, which Operator can satisfy a goal, and which assets are
+members of a dynamic Collection. → [ADR-006](../decisions/ADR-006-rule-engine-deferral.md)
 
-This borrows Backstage's useful envelope/type-specific-data boundary without copying its entity
-identity model. Sidereal does not add `namespace` until a concrete scoping requirement exists;
-Source instances, Collections, and opaque IDs cover the current cases. Paths and external IDs are
-core-managed state and relationships, not identity fields in the envelope. The full envelope/facet
-contract is [ADR-008](../decisions/ADR-008-facet-schema-and-write-authority.md).
+**Lineage** — directed edges between immutable AssetVersions recording exactly which bytes derived from
+which (`stacked ← 187 lights + master_dark_v3 + master_flat_Ha`). The single highest-value thing v0.10.x
+cannot do. → [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md)
 
-**Identity is immutable and independent of path.** Renaming or moving a file changes the path, not
-the asset. This is the invariant that makes Sidereal safe to let loose on a user's filesystem: if
-identity were path-derived, the system reorganising a tree would destroy its own references.
+**Processing Goal** — a durable statement of an outcome that must become true for a version or snapshot
+(`metadata.extracted`, `astro.plate_solved`, `published:immich`). A versioned **Processing Policy** uses
+a Selector to declare desired outcomes; it does not prescribe an Operator sequence. A level-triggered
+reconciler compares desired outcomes with recorded state and dispatches any eligible Operator, so only
+real data dependencies impose ordering and missed events recover on a sweep. An unsatisfied goal is
+always inspectable (`pending`/`running`/`blocked`/`needs_attention`) — no pipeline cursor to get
+opaquely stuck. → [ADR-006](../decisions/ADR-006-rule-engine-deferral.md)
 
-`kind` is **not** a fixed enum. `light | dark | flat | master | stacked` is astro vocabulary
-contributed by the astro domain pack, not core vocabulary. See
-[Core and domain packs](#core-and-domain-packs).
-
-> **[ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md) — accepted:** stable
-> surrogate Asset identity plus immutable content-addressed AssetVersions. The exact on-disk tree and
-> retention policy are still to be settled before M1.
-
-### Collection
-
-A generic grouping of assets. A **session** — target, date, location, rig, frames — is one
-specialisation; an album is another. A Collection may have explicit membership or a Selector that
-defines dynamic membership. Processing always binds a specific immutable membership snapshot, so a
-Collection changing underneath a run cannot change its inputs retroactively.
-
-Derived values are always derived. Integration totals are computed from member assets and their
-facets; they are never typed in and never denormalised onto a row that can drift. (v0.10.x does
-denormalise them onto the `Image` row, which is why a manual edit to `frameCount` survives until the
-next recompute silently overwrites it.)
-
-### Selector
-
-A **Selector** is the shared, deterministic predicate for deciding what applies to an AssetVersion or
-Collection. The common selector vocabulary covers `kind`, source instance, typed facets, and
-Collection membership. Core owns evaluation, indexing, and a match explanation; plugins and domain
-packs supply facet schemas and values, not custom matching code.
-
-Facets are the only extensible selection metadata in M0. A facet schema declares its type, scope,
-mutability, ownership, and indexing: `core.processing.mode=auto` can be an Asset-scoped mutable
-string, while `astro.fits.ccd_temp=-10.2` is an AssetVersion-scoped numeric observation. `kind`
-remains the domain pack's distinguished type discriminator.
-
-A Source configuration may assign an initial `kind` and configured facet values to every asset it
-ingests. The Source may also propose detected facets within its grants, but it never chooses
-Operators. Changing kind, facets, or selector-backed Collection membership prompts reconciliation.
-Source types and domain packs may offer defaults; the configured Source instance owns the final
-values. A mixed-kind Source may leave `kind` unset initially or classify each asset from ingested
-metadata.
-
-Selectors serve three related purposes:
-
-1. A Processing Policy selector decides **which goals apply** to a subject.
-2. An Operator `accepts` selector decides **whether that implementation can satisfy** a goal for the
-   subject.
-3. A Collection selector decides **which assets are members** of a dynamic Collection.
-
-Conceptually, without fixing the manifest syntax:
-
-```
-Source defaults:       kind=astro.stacked, facet core.processing.mode=auto
-Policy selector:       kind=astro.stacked + core.processing.mode=auto
-                       → require metadata, solve, thumbnail
-Plate-solve Operator:  provides solve; accepts astro image kinds with readable bytes
-Collection selector:   facet astro.target.catalog_id=M31 + kind=astro.light
-```
-
-Core dispatches an Operator only when the policy selected the subject, the Operator provides the
-missing outcome, its `accepts` selector matches, and its prerequisites are satisfied. The selector
-and the evidence used to match it are recorded so “why did this run?” remains answerable.
-
-The selector language is deliberately bounded: boolean composition plus existence, equality, set,
-and typed facet comparisons. It is data, not arbitrary plugin code, so matching remains indexable and
-explainable. Core rejects dependency cycles between selector-backed Collections.
-
-### Lineage
-
-Directed edges between immutable AssetVersions recording exactly which bytes were derived from which:
-
-```
-stacked_M31_2026-03-14  ←  [187 × light]  +  [master_dark_v3]  +  [master_flat_Ha]
-master_dark_v3          ←  [50 × dark @ -10°C, gain 100, 300s]
-```
-
-This is the single highest-value thing the current application cannot do, and the reason the rewrite
-is a rewrite rather than a refactor.
-
-An Asset is the stable logical identity used by collections, links, and external mappings. Lineage
-and Operation Runs point to immutable versions, so a move does not disturb references and a
-byte-level rewrite cannot erase history. Path-only moves remain Asset events; byte changes produce a
-new version. [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md) fixes the complete
-identity, revision, reconciliation, and retention rules.
-
-### Processing Goal
-
-A durable statement of an outcome that must become true for a specific AssetVersion or immutable
-Collection snapshot — for example `metadata.extracted`, `astro.plate_solved`,
-`thumbnail.available`, or `published:immich`. A versioned **Processing Policy** uses a Selector to
-declare the desired outcomes for matching assets and collections; it does not prescribe an Operator
-sequence.
-
-The reconciler compares desired outcomes with recorded facets, artifacts, lineage, and external
-receipts. It dispatches any eligible Operator capable of satisfying a missing goal, then reevaluates.
-Operators declare their prerequisites and outcomes, so only real data dependencies impose ordering;
-independent work may run concurrently. Completion means every applicable goal is satisfied, not that
-a workflow cursor reached its final step.
-
-State-change events such as asset ingestion prompt reconciliation, but they are not the source of
-truth. A periodic sweep repairs missed events and resumes after crashes. Manual actions use the same
-model by adding an explicit goal. Before cutover, domain packs supply built-in policies; user-authored
-policy rules and their editor arrive later.
-
-An unsatisfied goal is always inspectable as `pending`, `running`, `blocked`, or `needs_attention`,
-with the missing prerequisite, active attempt, retry budget, or ambiguous external effect recorded.
-There is no long-lived Pipeline Run to become opaquely stuck.
-
-### Operation Run
-
-A job record: which Operator and version ran, which Processing Goals it attempted, exact input and
-output AssetVersions, params, causal and idempotency keys, side-effect state, status, and log output.
-
-History is exact because intent and content versions are recorded rather than reconstructed from side
-effects. Re-run eligibility is determined by the Operator's side-effect class and idempotency
-protocol; an ambiguous external publish is not blindly replayed. This is also the unit that progress,
-retries, cancellation, and concurrency limits attach to.
-
----
+**Operation Run** — the exact record of one Operator attempt: which Operator/version ran, the goals it
+addressed, input and output versions, params, idempotency key, side-effect state, status, and logs.
+Re-run eligibility follows the Operator's side-effect class; an ambiguous external publish is not blindly
+replayed. → [ADR-006](../decisions/ADR-006-rule-engine-deferral.md)
 
 ## Plugin model
 
-Three capabilities, one registration mechanism. A plugin may implement more than one — Immich is
-both a Source and a Sink.
+Three capabilities, one registration mechanism; a plugin may implement more than one (Immich is both
+Source and Sink).
 
 | Capability | Contract | Examples |
 |---|---|---|
-| **Source** | Produces assets | Watch folder · Immich import · NINA/SGP session output · manual upload |
-| **Operator** | Takes assets + params, produces mutations and/or new assets | Plate solve · rename · move · tag · extract metadata · *later:* Siril invocation, AI detection |
+| **Source** | Produces assets | Watch folder · Immich import · NINA/SGP output · manual upload |
+| **Operator** | Takes assets + params → mutations and/or new assets | Plate solve · rename · move · tag · extract metadata · *later:* Siril, AI detection |
 | **Sink** | Publishes assets outward | Immich · static gallery · Astrobin · S3 |
 
-All built-in functionality uses the same semantic contract and conformance suite. Execution profiles
-may differ: trusted hot-path behavior can be compiled Rust, lightweight public plugins use embedded
-Rhai, and heavy or OS-specific integrations use an external provider. Every profile receives the
-same capability-limited `AssetContext`; none receives an unconstrained filesystem back door.
-
-Source, Operator, and Sink contracts are versioned independently and freeze only after each is
-dogfooded by realistic consumers. At least two initial built-ins also ship as Rhai plugins to prove
-the public scripting surface.
-
-The full contract — manifest, capability declaration, config schema, execution model, conformance
-suite — is in **[plugins.md](plugins.md)**.
-
----
+All profiles implement the same semantic contract and conformance suite; only the transport differs
+(built-in Rust, embedded Rhai script, or external provider), and every profile receives the same
+capability-limited `AssetContext` — no filesystem back door. The full contract is in
+**[plugins.md](plugins.md)**; the execution profiles and trust model are
+[ADR-001](../decisions/ADR-001-plugin-boundary.md) and
+[ADR-007](../decisions/ADR-007-security-and-plugin-trust.md).
 
 ## Core and domain packs
 
-If Sidereal could plausibly become a general media manager one day, `kind` must not be a Rust enum
-containing `light | dark | flat`. Splitting this now costs almost nothing. Splitting it later is a
-migration.
+`kind` must not be a Rust enum containing `light | dark | flat`. **Core** is domain-agnostic (Asset,
+Collection, Selector, Lineage, Processing Goal, Operation Run, plugin/policy registries, storage, search,
+job queue, web shell). **Domain packs** are plugins: the astro pack contributes the
+`light/dark/flat/master/stacked` vocabulary, FITS/XISF readers, OpenNGC catalog, plate solving, sky map,
+equipment, acquisitions, and visibility math. → [ADR-002](../decisions/ADR-002-core-domain-pack-split.md)
 
-**Core (domain-agnostic):** Asset and its metadata envelope, Collection, Selector, Lineage,
-Processing Goal, Operation Run, processing policy registry, plugin registry, storage layout,
-search/index, job queue, web shell.
-
-**Domain packs (plugins):** the astro pack contributes the `light/dark/flat/master/stacked`
-vocabulary, FITS/XISF readers, the OpenNGC catalog, plate solving, sky map, equipment, acquisitions,
-and visibility math. A future family-photos pack would contribute faces, duplicates, and EXIF-centric
-views. Neither is privileged in core.
-
-### The mechanism: metadata facets
-
-Rather than a wide table of astro columns, an asset carries **namespaced, searchable facets** whose
-schemas are declared by a pack:
-
-```
-astro.fits.exptime        astro.solve.ra          photo.exif.iso
-astro.fits.ccd_temp       astro.solve.pixscale    photo.exif.lens
-astro.fits.gain           astro.solve.fov         ai.faces.count
-```
-
-Core knows how to store, index, and query facets. It does not know what any of them mean. A pack
-exclusively owns each schema, but compatible producer plugins can receive write grants. Values retain
-producer and version provenance; [ADR-008](../decisions/ADR-008-facet-schema-and-write-authority.md)
-defines the namespace and evolution rules.
-
-Facets cover both mutable intent and observed or derived facts. Their schemas make the distinction
-explicit through type, scope, mutability, units, and provenance rather than through a second metadata
-mechanism. `core.processing.mode=auto` can opt an Asset into a policy, while
-`astro.fits.ccd_temp=-10.2` remains an AssetVersion-scoped numeric observation available to a range
-predicate. Raw source evidence and a normalized decision are different facts — for example,
-`astro.fits.image_type=LIGHT` may be the evidence used to classify the envelope as
-`kind=astro.light`.
-
-Selectors depend on canonical facet schema names, not producer plugins. Built-in policies may
-reference only schemas owned by core or the relevant domain pack; alternative plugins receive grants
-to produce those schemas. A user may deliberately select a plugin-owned facet, but the UI must expose
-that portability dependency.
-
-This is also what makes **per-kind processing policies** natural later. A policy matches on kind and
-facets, so `kind = light` requires one set of outcomes and `kind = dark` another, with no core
-changes. Calibration-master matching — "find a master dark for this camera at -10 °C, gain 100,
-300 s, bin 1×1" — is a facet query, not bespoke schema.
-
-**What this requires of the storage engine** (input to ADR-004):
-
-- Indexed lookup on semi-structured facet values.
-- Recursive traversal for lineage graphs ("everything derived from this master, transitively").
-- A zero-config single-user install experience.
-
-SQLite (JSON1 + recursive CTEs) and PostgreSQL both satisfy the first two. **ADR-004 is accepted as
-PostgreSQL-only** (JSONB + GIN for facets, best recursive-CTE performance, one dialect); the
-zero-config requirement is met at the packaging layer — an all-in-one image / compose bundle — rather
-than by a serverless engine.
-
----
+The mechanism is **namespaced, searchable facets** (`astro.fits.ccd_temp`, `astro.solve.ra`,
+`photo.exif.iso`). Core stores, indexes, and queries facets without knowing what any of them mean; a pack
+owns each schema, and compatible producers get write grants with retained provenance. This is what makes
+calibration-master matching — "a master dark for this camera at −10 °C, gain 100, 300 s, bin 1×1" — a
+facet query rather than bespoke schema. → [ADR-008](../decisions/ADR-008-facet-schema-and-write-authority.md)
 
 ## Architecture decisions
 
-Every architectural decision has an ADR in [`docs/decisions/`](../decisions/) — read those for the
-full context, options, and rationale. All are M0 work. **ADR-005 is still open**; the rest are
-accepted.
+Each decision has an ADR in [`docs/decisions/`](../decisions/) with the full context, options, and
+rationale. All are M0 work. **ADR-005 is still open**; the rest are accepted.
 
 | ADR | Decision | Status |
 |---|---|---|
 | [001](../decisions/ADR-001-plugin-boundary.md) | Plugin contract & execution profiles | Accepted |
 | [002](../decisions/ADR-002-core-domain-pack-split.md) | Core / domain-pack seam | Accepted |
 | [003](../decisions/ADR-003-storage-layout-and-asset-identity.md) | Storage layout & asset identity | Accepted |
-| [004](../decisions/ADR-004-database-engine-and-schema.md) | Database engine & schema strategy | Accepted |
+| [004](../decisions/ADR-004-database-engine-and-schema.md) | Database engine & schema strategy | Accepted (PostgreSQL-only) |
 | [005](../decisions/ADR-005-frontend-continuity.md) | Frontend continuity | **Proposed** — gated on the contributor conversation + a green v0.10.x E2E baseline |
 | [006](../decisions/ADR-006-rule-engine-deferral.md) | Declarative processing & policy deferral | Accepted |
 | [007](../decisions/ADR-007-security-and-plugin-trust.md) | Security & plugin trust | Accepted |
 | [008](../decisions/ADR-008-facet-schema-and-write-authority.md) | Metadata envelope, facets & write authority | Accepted |
 
-**ADR-001 and ADR-007 are coupled.** The execution profile says how code runs; grants and
-`AssetContext` say what it is allowed to do. Neither decision is complete without the other.
-
----
+**ADR-001 and ADR-007 are coupled** — the execution profile says how code runs; grants and
+`AssetContext` say what it may do. Neither is complete without the other.
 
 ## Milestone map
 
-Critical path is **M0 → M1 → M2**. Everything else fans out behind it. If the plugin interface is
-wrong, we find out at M2 rather than M6 — that is the entire point.
+Critical path is **M0 → M1 → M2**. If the plugin interface is wrong, we find out at M2 rather than M6.
 
 ```mermaid
 graph LR
@@ -391,102 +175,35 @@ graph LR
     M6 --> M7[M7+ North star<br/>proper]
 ```
 
-| Milestone | Size | Exit criterion |
-|---|---|---|
-| **M0** Contracts & scaffolding | S–M | Eight ADRs accepted, including security and plugin grants; Rhai/AssetContext spike complete; CI green; a contributor goes zero-to-running in one command |
-| **M1** Core spine & first plugins | L | In a disposable root, drop a file in a watched folder → it appears in the UI with extracted metadata entirely through plugin contracts |
-| **M2** Operator engine & Operator API v0.1 | M–L | Operator API, `AssetContext`, selector contract, side-effect protocol, and author guide published; four built-ins consume it, at least two through Rhai; applicability explanations, durable goals, reconciliation, and recovery after missed events proven |
-| **M3** Astro domain pack | L | Source facets and built-in policy selectors converge a full session from ingest — lights + darks + flats → session grouped, masters matched, lineage recorded |
-| **M4** Sources, sinks & importer | M | A real v0.10.1 install imports cleanly and reports what didn't map |
-| **M5** Frontend parity | L | Every non-negotiable cutover item green |
-| **M6** Cutover | M | Docker parity, migration guide, beta with real users, `v2.0.0` |
-| **M7+** North star proper | — | User-authored processing policies · Siril/PixInsight integration · AI plugins · general-media pack exploration |
+| Milestone | Exit criterion |
+|---|---|
+| **M0** Contracts & scaffolding | Eight ADRs accepted; Rhai/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
+| **M1** Core spine & first plugins | Drop a file in a watched folder → it appears in the UI with extracted metadata, entirely through plugin contracts |
+| **M2** Operator engine & API v0.1 | Operator API, `AssetContext`, selector contract, side-effect protocol published; four built-ins consume it, ≥2 through Rhai; durable goals, reconciliation, and recovery-after-missed-events proven |
+| **M3** Astro domain pack | Source facets + built-in policy converge a full session — lights + darks + flats → grouped, masters matched, lineage recorded |
+| **M4** Sources, sinks & importer | A real v0.10.x install imports cleanly and reports what didn't map |
+| **M5** Frontend parity | Every non-negotiable cutover item green (starts at M1, parallel to backend) |
+| **M6** Cutover | Docker parity, migration guide, beta with real users, `v2.0.0` |
+| **M7+** North star proper | User-authored policies · Siril/PixInsight · AI plugins · general-media pack exploration |
 
-### Parallelism
+**M5 starts at M1**, not last — the frontend is a separate workstream against the HTTP API and stays
+TypeScript/React. This is the single most important scheduling decision in the plan: it keeps existing
+frontend contributors productive through a backend language switch.
 
-**M5 is listed last but starts at M1.** The frontend is a separate workstream against the HTTP API
-and stays TypeScript/React. This is the single most important scheduling decision in the plan: it is
-what keeps existing frontend contributors productive through a backend language switch.
+## Migration & cutover
 
-Third-party plugin work opens at M2. The astro pack (M3) is separable from core once the interface is
-frozen, so it can split across people too.
-
----
-
-## Migration and cutover
-
-**Clean break with a one-way importer**, gated on a non-negotiable feature set.
-
-v2 is a new data model. The TypeScript app moves to maintenance — security and critical fixes only,
-no features — and is retired at cutover. The importer reads an existing SQLite/Postgres database and
-storage tree and produces v2 assets: best-effort, lossy where the models genuinely differ, and it
-**emits a report of exactly what didn't map**.
-
-### On the compatibility requirements in the analysis package
-
-`13-compatibility-requirements.md` states that a replacement MUST preserve image IDs, the storage
-layout `{STORAGE_PATH}/processed/{id % 1000}/{id}/…`, every API path and shape, and reconciling-sync
-semantics.
-
-**This architecture does not honour that, and cannot.** Those requirements describe a system where
-Immich owns the tree and an `Image` is a finished photo. Both premises are what v2 exists to change.
-The analysis package remains valuable as a behavioural inventory and as the source of the cutover
-gate below — but it is not a contract v2 is bound by.
-
-### Non-negotiable before cutover
-
-An existing user would consider the upgrade broken without these:
-
-- [ ] Gallery browse / filter / search with deep links
-- [ ] Image detail view and metadata editing
-- [ ] Deep-zoom viewer
-- [ ] Plate solving, single and bulk
-- [ ] Targets: catalog browse, visibility, annotations
-- [ ] Equipment and equipment groups
-- [ ] Acquisition entries and integration totals
-- [ ] Immich sync as a source
-- [ ] Admin configuration UI with connection tests
-- [ ] Docker parity — port 5000, volume mounts, PUID/PGID, healthcheck
-- [ ] Saved locations and their session relationships
-- [ ] One-way importer from v0.10.x with dry-run and reconciliation report
-
-**Should-have, not blocking:** sky map with FOV overlay · notifications · live job updates ·
-dashboard stats.
-
-**Proposed compatibility breaks pending a deployment survey/data scan:** XMP sidecar generation ·
-standalone worker mode. Current evidence establishes uncertain lifecycle or usage, not absence of
-users. Before accepting the break, survey deployments and inspect available configuration/telemetry;
-if dropped, the importer reports affected records explicitly.
-
-**Explicitly dropped:** the database-download API endpoint (unauthenticated full-database download;
-replaced by documented volume backup) · legacy free-text `telescope`/`camera`/`mount` fields
-(superseded by equipment relations).
-
-**Pre-cutover filesystem safety:** M1–M5 builds operate only on copied or disposable storage roots.
-They do not rename, move, or delete irreplaceable originals. The importer is read-only against the
-source tree, supports dry-run and resumable execution, records legacy-ID mappings, verifies checksums,
-and reconciles source/destination counts. Its hard invariant is that every irreplaceable local or URL
-original is either imported and verified or named in the failure report; an unaccounted original
-blocks cutover.
-
-**Rollback:** before M6, rollback means discarding the disposable v2 root while v0.10.x and its source
-tree remain untouched. At M6, the migration guide requires a verified database and storage backup
-before import. After cutover, rollback restores that backup. The importer remains one-way by design.
-
----
+A **clean break with a one-way importer**, gated on a non-negotiable feature set. The full cutover gate —
+the required-before-cutover checklist, compatibility breaks, filesystem-safety invariants, and rollback —
+lives in **[migration.md](migration.md)**.
 
 ## What this document is not
 
-- **Not a plan.** Milestones are sub-issues under #213; the plan lives there.
-- **Not fully accepted.** #213 is `status/ready`, and seven of the eight M0 ADRs are accepted;
-  [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend continuity) is still Proposed.
-  Until its Decision is filled in, the frontend approach is a leaning.
-- **Not a v0.10.x reference.** [Where we are](#where-we-are) is a summary; the authoritative record of
-  current behaviour is the [analysis package](https://github.com/sidereal-io/sidereal-analysis).
+- **Not a plan.** Milestones are sub-issues under #213.
+- **Not fully accepted.** #213 is `status/ready`; ADR-005 is still Proposed, so the frontend approach is
+  a leaning.
+- **Not a v0.10.x reference.** The authoritative record of current behaviour is the
+  [analysis package](https://github.com/sidereal-io/sidereal-analysis).
 
-### Changing it
-
-Architectural changes go through an ADR in [`docs/decisions/`](../decisions/), then this document is
-updated in the same PR. If you are resolving the remaining open ADR, fill in its Decision section,
-flip its status to Accepted, and update the [decision index](#architecture-decisions) and any
-provisional statement it settles.
+**Changing it:** an architectural change goes through an ADR in [`docs/decisions/`](../decisions/), then
+this map is updated in the same PR. Resolving ADR-005 means filling in its Decision, flipping its status,
+and updating the [decision index](#architecture-decisions) above.

--- a/docs/architecture/migration.md
+++ b/docs/architecture/migration.md
@@ -1,0 +1,66 @@
+# Migration & Cutover
+
+**Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) · **Last updated:** 2026-08-19 ·
+Part of the [architecture reference](README.md).
+
+v2 is a new data model. The strategy is a **clean break with a one-way importer**, gated on a
+non-negotiable feature set. The TypeScript app moves to maintenance (security and critical fixes only)
+and is retired at cutover. The importer reads an existing SQLite/Postgres database and storage tree and
+produces v2 assets — best-effort, lossy where the models genuinely differ, and it **emits a report of
+exactly what didn't map**.
+
+## On the analysis package's compatibility requirements
+
+`13-compatibility-requirements.md` states a replacement MUST preserve image IDs, the storage layout
+`{STORAGE_PATH}/processed/{id % 1000}/{id}/…`, every API path and shape, and reconciling-sync semantics.
+
+**v2 does not honour that, and cannot.** Those requirements describe a system where Immich owns the tree
+and an `Image` is a finished photo — both premises are exactly what v2 exists to change. The analysis
+package stays valuable as a behavioural inventory and as the source of the cutover gate below, but it is
+not a contract v2 is bound by.
+
+## Non-negotiable before cutover
+
+An existing user would consider the upgrade broken without these:
+
+- [ ] Gallery browse / filter / search with deep links
+- [ ] Image detail view and metadata editing
+- [ ] Deep-zoom viewer
+- [ ] Plate solving, single and bulk
+- [ ] Targets: catalog browse, visibility, annotations
+- [ ] Equipment and equipment groups
+- [ ] Acquisition entries and integration totals
+- [ ] Immich sync as a source
+- [ ] Admin configuration UI with connection tests
+- [ ] Docker parity — port 5000, volume mounts, PUID/PGID, healthcheck
+- [ ] Saved locations and their session relationships
+- [ ] One-way importer from v0.10.x with dry-run and reconciliation report
+
+**Should-have, not blocking:** sky map with FOV overlay · notifications · live job updates · dashboard
+stats.
+
+**Compatibility breaks pending a deployment survey/data scan:** XMP sidecar generation · standalone
+worker mode. Current evidence shows uncertain lifecycle or usage, not absence of users. Survey
+deployments and inspect available configuration/telemetry before accepting the break; if dropped, the
+importer reports affected records explicitly.
+
+**Explicitly dropped:** the database-download API endpoint (unauthenticated full-database download;
+replaced by documented volume backup) · legacy free-text `telescope`/`camera`/`mount` fields (superseded
+by equipment relations).
+
+## Filesystem safety
+
+M1–M5 builds operate only on copied or disposable storage roots. They never rename, move, or delete
+irreplaceable originals. The importer is read-only against the source tree, supports dry-run and resumable
+execution, records legacy-ID mappings, verifies checksums, and reconciles source/destination counts. Its
+hard invariant: every irreplaceable local or URL original is either imported and verified or named in the
+failure report — an unaccounted original blocks cutover.
+
+## Rollback
+
+- **Before M6:** discard the disposable v2 root; v0.10.x and its source tree remain untouched.
+- **At M6:** the migration guide requires a verified database and storage backup before import.
+- **After cutover:** rollback restores that backup. The importer is one-way by design.
+
+Because ADR-004 accepts PostgreSQL-only, backup guidance covers the Postgres volume (and `pg_dump`) in
+place of the old SQLite-file copy.

--- a/docs/architecture/migration.md
+++ b/docs/architecture/migration.md
@@ -63,5 +63,6 @@ failure report — an unaccounted original blocks cutover.
 - **At M6:** the migration guide requires a verified database and storage backup before import.
 - **After cutover:** rollback restores that backup. The importer is one-way by design.
 
-Because ADR-004 accepts PostgreSQL-only, backup guidance covers the Postgres volume (and `pg_dump`) in
-place of the old SQLite-file copy.
+A verified backup covers **both** stores: the PostgreSQL database (via `pg_dump` or a volume snapshot —
+ADR-004 makes Postgres the only engine) **and** the v2 asset-storage root on disk. Neither alone is
+complete, and the SQLite-era file-copy guidance no longer covers the database.

--- a/docs/architecture/migration.md
+++ b/docs/architecture/migration.md
@@ -4,8 +4,9 @@
 Part of the [architecture reference](README.md).
 
 v2 is a new data model. The strategy is a **clean break with a one-way importer**, gated on a
-non-negotiable feature set. The TypeScript app moves to maintenance (security and critical fixes only)
-and is retired at cutover. The importer reads an existing SQLite/Postgres database and storage tree and
+non-negotiable feature set — the decision and its rationale are
+[ADR-010](../decisions/ADR-010-migration-strategy.md); this doc owns the execution. The TypeScript app
+moves to maintenance (security and critical fixes only) and is retired at cutover. The importer reads an existing SQLite/Postgres database and storage tree and
 produces v2 assets — best-effort, lossy where the models genuinely differ, and it **emits a report of
 exactly what didn't map**.
 

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -154,7 +154,7 @@ An Operator returns status, proposed core-managed mutations, zero or more new as
 declarations, external receipts, goal-satisfaction evidence, and log output. Core validates the
 complete result before committing core-managed effects.
 
-Every run is recorded as an [Operation Run](README.md#operation-run): Operator and version, addressed
+Every run is recorded as an [Operation Run](README.md#core-concepts): Operator and version, addressed
 Processing Goals, inputs and input versions, params, outputs, status, side-effect state, and logs.
 
 The execution profiles differ only in how requests and results cross the adapter. Built-in Rust uses

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -6,8 +6,8 @@ Everything Sidereal v2 *does* to a user's files uses the plugin contract. This d
 a plugin receives, what it may request, what it returns, and how it proves conformance.
 
 The contract is **transport-independent**. [ADR-001](../decisions/ADR-001-plugin-boundary.md) defines
-three execution profiles — built-in Rust, embedded Rhai, and an external provider — over the same
-semantics. Built-ins do not receive an unconstrained private API merely because they are compiled in.
+three execution profiles — built-in Rust, embedded script (Rhai, pending the M0 spike), and an external
+provider — over the same semantics. Built-ins do not receive an unconstrained private API merely because they are compiled in.
 
 ## Contents
 
@@ -109,7 +109,7 @@ A plugin ships a manifest declaring:
 | `capability_grants` | Requested host functions, allowlisted network destinations, byte-access mode, and secret names. Installation requires explicit approval. |
 | `requires` | Declared external dependencies or provider endpoints so unmet requirements surface before a run. |
 
-Built-in Rust plugins ship with Sidereal. Script plugins are manifest-plus-Rhai bundles loaded by
+Built-in Rust plugins ship with Sidereal. Script plugins are manifest-plus-script bundles loaded by
 core. External providers are separately installed services or agents; Sidereal v0.1 validates and
 connects to their endpoints but does not orchestrate their containers or language environments.
 
@@ -158,8 +158,8 @@ Every run is recorded as an [Operation Run](README.md#core-concepts): Operator a
 Processing Goals, inputs and input versions, params, outputs, status, side-effect state, and logs.
 
 The execution profiles differ only in how requests and results cross the adapter. Built-in Rust uses
-an in-process trait, Rhai uses registered host functions, and external providers use an authenticated
-protocol. Shared fixtures and conformance tests verify the same semantics.
+an in-process trait, the embedded script engine uses registered host functions, and external providers
+use an authenticated protocol. Shared fixtures and conformance tests verify the same semantics.
 
 If a legacy external tool requires a path, core provides a read-only mount or disposable workspace
 and verifies input hashes after execution. Produced files are imported and hashed before becoming
@@ -242,8 +242,8 @@ semantic suite is a bug in the built-in or interface — never an exemption.
 Each capability contract is versioned independently. Core refuses an incompatible capability at load
 time rather than failing partway through a run.
 
-Operator API v0.1 is targeted for M2 after four built-ins, including at least two Rhai
-implementations, consume it unchanged. Source API v0.1 follows real watch-folder and Immich Sources.
+Operator API v0.1 is targeted for M2 after four built-ins, including at least two through the embedded
+script profile, consume it unchanged. Source API v0.1 follows real watch-folder and Immich Sources.
 Sink API v0.1 follows a real Immich or filesystem-gallery Sink. A `v0.2` of each is expected — a
 freeze buys a stable target, not permanent immutability.
 

--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -1,0 +1,37 @@
+# Roadmap — Milestone Map
+
+**Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) · **Last updated:** 2026-08-19 ·
+Part of the [architecture reference](README.md).
+
+The build shape. Milestones are tracked as **sub-issues under [#213](https://github.com/sidereal-io/sidereal/issues/213)**,
+which is the plan of record; this page is the map and the exit criteria.
+
+Critical path is **M0 → M1 → M2**. If the plugin interface is wrong, we find out at M2 rather than M6.
+
+```mermaid
+graph LR
+    M0[M0 Contracts<br/>& scaffolding] --> M1[M1 Core spine<br/>& first plugins]
+    M1 --> M2[M2 Operator engine<br/>& Operator API v0.1]
+    M2 --> M3[M3 Astro<br/>domain pack]
+    M2 --> M4[M4 Sources, sinks<br/>& importer]
+    M1 -.parallel.-> M5[M5 Frontend<br/>parity]
+    M3 --> M6[M6 Cutover]
+    M4 --> M6
+    M5 --> M6
+    M6 --> M7[M7+ North star<br/>proper]
+```
+
+| Milestone | Exit criterion |
+|---|---|
+| **M0** Contracts & scaffolding | All M0 ADRs accepted (ADR-005 the last open one), including security and plugin grants; Rhai/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
+| **M1** Core spine & first plugins | Drop a file in a watched folder → it appears in the UI with extracted metadata, entirely through plugin contracts |
+| **M2** Operator engine & API v0.1 | Operator API, `AssetContext`, selector contract, side-effect protocol published; four built-ins consume it, ≥2 through Rhai; durable goals, reconciliation, and recovery-after-missed-events proven |
+| **M3** Astro domain pack | Source facets + built-in policy converge a full session — lights + darks + flats → grouped, masters matched, lineage recorded |
+| **M4** Sources, sinks & importer | A real v0.10.x install imports cleanly and reports what didn't map |
+| **M5** Frontend parity | Every non-negotiable cutover item green (starts at M1, parallel to backend) |
+| **M6** Cutover | Docker parity, migration guide, beta with real users, `v2.0.0` |
+| **M7+** North star proper | User-authored policies · Siril/PixInsight · AI plugins · general-media pack exploration |
+
+**M5 starts at M1**, not last — the frontend is a separate workstream against the HTTP API and stays
+TypeScript/React. This is the single most important scheduling decision in the plan: it keeps existing
+frontend contributors productive through a backend language switch.

--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -25,7 +25,7 @@ graph LR
 |---|---|
 | **M0** Contracts & scaffolding | All M0 ADRs accepted (ADR-005 the last open one), including security and plugin grants; Rhai/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
 | **M1** Core spine & first plugins | Drop a file in a watched folder → it appears in the UI with extracted metadata, entirely through plugin contracts |
-| **M2** Operator engine & API v0.1 | Operator API, `AssetContext`, selector contract, side-effect protocol published; four built-ins consume it, ≥2 through Rhai; durable goals, reconciliation, and recovery-after-missed-events proven |
+| **M2** Operator engine & API v0.1 | Operator API, `AssetContext`, selector contract, side-effect protocol published; four built-ins consume it, ≥2 through the embedded script profile; durable goals, reconciliation, and recovery-after-missed-events proven |
 | **M3** Astro domain pack | Source facets + built-in policy converge a full session — lights + darks + flats → grouped, masters matched, lineage recorded |
 | **M4** Sources, sinks & importer | A real v0.10.x install imports cleanly and reports what didn't map |
 | **M5** Frontend parity | Every non-negotiable cutover item green (starts at M1, parallel to backend) |

--- a/docs/decisions/ADR-000-template.md
+++ b/docs/decisions/ADR-000-template.md
@@ -29,9 +29,12 @@ What question needs answering? What constraint or trade-off exists?
 
 ## Recommendation
 
-Which option do you recommend and why? What's the key differentiator?
+Which option do you recommend, and why? Put the reasoning and any coupled
+sub-calls here — this is the substantive proposal, and where the "why" lives.
 
 ## Decision
 
-[Filled in by developer after review. State the chosen option and any
-conditions or caveats.]
+Filled in after review. If the decision **matches** the Recommendation, ratify it
+in one line — e.g. "Accepted YYYY-MM-DD — Option B, as recommended." Do not restate
+the Recommendation's content. Only write prose here when the decision **diverges**
+from the Recommendation: say what changed and why.

--- a/docs/decisions/ADR-001-plugin-boundary.md
+++ b/docs/decisions/ADR-001-plugin-boundary.md
@@ -109,30 +109,21 @@ defined by [ADR-007](ADR-007-security-and-plugin-trust.md).
 
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213). Adopt the **capability-oriented hybrid** from the
-Recommendation, with three execution profiles behind one semantic contract:
+Accepted 2026-08-18 (M0 of RFC #213). Adopt the **capability-oriented hybrid** from the Recommendation:
+the three execution profiles in the table above (built-in Rust, embedded script, external provider)
+behind one semantic contract, each passing the same capability-specific conformance suite with only the
+transport differing. This is **not** the rejected "hybrid" where built-ins get an unconstrained private
+API — core keeps authority through the capability-limited `AssetContext` above; no profile gets ambient
+asset, secret, process, or network access.
 
-- **Built-in Rust** — trusted, first-party, performance-sensitive behavior (FITS/XISF readers,
-  storage adapters, core astro Operators), compiled into the binary as crates.
-- **Embedded script** — the default public extension surface for lightweight Operators, Sources, and
-  Sinks; a manifest plus script source in a plugin bundle loaded by Sidereal.
-- **External provider** — a separately installed, user-managed service or agent for Python ML,
-  Siril/PixInsight/ASTAP, and hardware- or OS-specific tools; the manifest configures its endpoint.
+Also decided here:
 
-All three implement identical Source/Operator/Sink request-and-result semantics and pass the same
-capability-specific conformance suite; only the transport adapter differs. This is explicitly **not**
-the rejected "hybrid" in which built-ins get an unconstrained private API. Core retains authority:
-plugins request effects through a capability-limited `AssetContext` and never receive ambient asset,
-secret, process, or network access.
-
-**No published Rust dynamic ABI** — compiler ABI instability rules out third-party dylibs.
-
-The initial scripting engine is **Rhai**, contingent on an M0 spike proving cancellation, operation
-and memory limits, async host calls, manifest loading, and the `AssetContext` API; **Rune and Lua are
-the fallbacks if that spike fails.** **WASM is deferred** until a concrete plugin needs portable
-compiled components the script profile cannot provide.
-
-Sidereal v0.1 does **not** orchestrate arbitrary plugin containers, provision Python environments, or
-manage external-provider upgrades; an external provider is an explicit, user-managed dependency. The
-embedded-script profile is declared stable only after **at least two built-ins also ship through it** —
-the initial candidates are tag/rename and API-based plate solving.
+- **No published Rust dynamic ABI** — compiler ABI instability rules out third-party dylibs.
+- **Rhai** is the initial scripting engine, contingent on the M0 spike (cancellation, operation/memory
+  limits, async host calls, manifest loading, `AssetContext`); **Rune and Lua are the fallbacks** if it
+  fails. **WASM is deferred** until a concrete plugin needs compiled components the script profile can't
+  provide.
+- v0.1 does **not** orchestrate plugin containers, provision Python environments, or manage
+  external-provider upgrades — an external provider is a user-managed dependency. The embedded-script
+  profile is declared stable only after **≥2 built-ins also ship through it** (initial candidates:
+  tag/rename and API-based plate solving).

--- a/docs/decisions/ADR-001-plugin-boundary.md
+++ b/docs/decisions/ADR-001-plugin-boundary.md
@@ -50,26 +50,24 @@ file bytes never cross a JSON/gRPC boundary — co-located providers get read-on
 paths, remote providers use explicit streaming. An M0 benchmark on a 500+ frame session sizes batching
 without reopening the semantic contract.
 
+**`AssetContext` is the only route from plugin code to core** — approved metadata/facets, mediated byte
+access (read-only stream, descriptor, mount, or disposable copy), emitting new assets and proposed
+facets, core-managed rename/move/tag/publish intents, allowlisted HTTP, manifest-declared run-scoped
+secrets, and logs/progress/cancellation. No profile gets a writable path into the store; core imports
+and hashes produced files into `AssetVersion` records. Host capabilities each carry their own timeout
+and cancellation. The full enumeration lives in [plugins.md](../architecture/plugins.md).
+
+Execution profile is not a trust level: built-in Rust is trusted first-party code, while script bundles
+and external providers get explicit capabilities at install, with authentication, grants, and secret
+delivery defined by [ADR-007](ADR-007-security-and-plugin-trust.md). There is **no published Rust dynamic
+ABI**. v0.1 does not orchestrate plugin containers, provision Python environments, or manage
+external-provider upgrades — an external provider is a user-managed dependency. The embedded-script
+profile is declared stable only after **≥2 built-ins also ship through it** (initial candidates:
+tag/rename and API-based plate solving). A compiled built-in can still panic with core, so only trusted
+first-party code belongs in that profile; WASM and container orchestration remain reversible later
+additions, not M0 prerequisites.
+
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213). Adopt the **capability-oriented hybrid** above: the three
-execution profiles behind one semantic contract, each passing the same capability-specific conformance
-suite with only the transport differing.
-
-- **`AssetContext` is the only route from plugin code to core** — approved metadata/facets, mediated
-  byte access (read-only stream, descriptor, mount, or disposable copy), emitting new assets and
-  proposed facets, core-managed rename/move/tag/publish intents, allowlisted HTTP, manifest-declared
-  run-scoped secrets, and logs/progress/cancellation. No profile gets a writable path into the store;
-  core imports and hashes produced files into `AssetVersion` records. Host capabilities each carry their
-  own timeout and cancellation. The full enumeration lives in [plugins.md](../architecture/plugins.md).
-- **Execution profile is not a trust level.** Built-in Rust is trusted first-party code; script bundles
-  and external providers get explicit capabilities at install. Authentication, grants, and secret
-  delivery are [ADR-007](ADR-007-security-and-plugin-trust.md).
-- **No published Rust dynamic ABI; WASM deferred; Rhai contingent on the M0 spike** (Rune/Lua as
-  fallbacks). v0.1 does **not** orchestrate plugin containers, provision Python environments, or manage
-  external-provider upgrades — an external provider is a user-managed dependency.
-- The embedded-script profile is declared stable only after **≥2 built-ins also ship through it**
-  (initial candidates: tag/rename and API-based plate solving).
-
-A compiled built-in can still panic with core, so only trusted first-party code belongs in that
-profile; WASM and container orchestration remain reversible later additions, not M0 prerequisites.
+Accepted 2026-08-18 (M0 of RFC #213) — the **capability-oriented hybrid**, as recommended. The embedded
+scripting engine (**Rhai**) is contingent on the M0 spike, with Rune/Lua as fallbacks.

--- a/docs/decisions/ADR-001-plugin-boundary.md
+++ b/docs/decisions/ADR-001-plugin-boundary.md
@@ -2,128 +2,74 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The plugin contract in [docs/architecture/plugins.md](../architecture/plugins.md) defines the common semantics; this ADR chooses how different classes of plugin execute and are installed.
+**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The plugin contract in
+[plugins.md](../architecture/plugins.md) defines the common semantics; this ADR chooses how different
+classes of plugin execute and are installed.
 
 ## Problem
 
-Every Sidereal v2 pipeline action uses the plugin contract, including built-ins. The original proposal
-treated "plugin contract" and "process boundary" as one decision, but the workloads do not share one
-useful boundary:
-
-- FITS/XISF parsing and other hot paths need low overhead.
-- User-authored rename, tag, metadata, and API orchestration should be easy to install and tightly
-  capability-limited.
-- Python ML, Siril, PixInsight, and ASTAP may require large native runtimes, another operating
-  system, or process isolation.
-
-Forcing all three through one runtime either makes the default install operationally complex or gives
-third-party code more authority than it needs. The contract and its execution transport therefore
-need separate decisions.
+Every v2 pipeline action uses the plugin contract, including built-ins. The original proposal treated
+"plugin contract" and "process boundary" as one decision, but the workloads do not share one useful
+boundary: FITS/XISF parsing and other hot paths need low overhead; user-authored rename/tag/metadata
+work should be easy to install and tightly capability-limited; Python ML, Siril, PixInsight, and ASTAP
+may need large native runtimes, another OS, or process isolation. Forcing all three through one runtime
+either makes the default install complex or over-grants third-party code. The contract and its
+execution transport therefore need separate decisions.
 
 ## Decision drivers
 
-- **One semantic contract.** Source, Operator, and Sink results mean the same thing under every
-  execution profile and run through the same conformance suite.
-- **Core retains authority.** Plugins request effects through an `AssetContext`; they do not receive
-  ambient write access to the asset store, arbitrary secrets, or an unrestricted process launcher.
+- **One semantic contract.** Source/Operator/Sink results mean the same thing under every profile and
+  run through the same conformance suite.
+- **Core retains authority.** Plugins request effects through a capability-limited `AssetContext`; no
+  ambient asset-store, secret, process, or network access.
 - **Simple default deployment.** Installing a normal plugin must not require another container or
   language runtime.
 - **Isolation where it matters.** A third-party native runtime may fail without taking down core.
-- **No published Rust dynamic ABI.** Rust compiler ABI stability makes dylibs unsuitable as the
-  third-party contract.
+- **No published Rust dynamic ABI** — compiler ABI instability rules out dylibs as the third-party
+  contract.
 
 ## Recommendation
 
-Adopt a **capability-oriented hybrid** with three execution profiles.
+A **capability-oriented hybrid** with three execution profiles behind one semantic contract:
 
-| Profile | Intended use | Packaging and installation |
+| Profile | Intended use | Packaging |
 |---|---|---|
-| **Built-in Rust** | Trusted, performance-sensitive first-party behavior: FITS/XISF readers, storage adapters, core astro operations | Compiled into the Sidereal binary as crates |
-| **Embedded script** | Default public extension surface for lightweight Operators, Sources, and Sinks | Manifest plus Rhai source in a plugin bundle loaded by Sidereal |
-| **External provider** | Python ML, Siril/PixInsight/ASTAP integration, hardware or OS-specific tools | Separately installed service or agent; the manifest configures its endpoint |
+| **Built-in Rust** | Trusted, performance-sensitive first-party behavior: FITS/XISF readers, storage adapters, core astro operations | Compiled into the binary as crates |
+| **Embedded script** | Default public extension surface for lightweight Operators, Sources, Sinks | Manifest + Rhai source in a plugin bundle |
+| **External provider** | Python ML, Siril/PixInsight/ASTAP, hardware- or OS-specific tools | Separately installed service; manifest configures its endpoint |
 
-The initial scripting engine is **Rhai**, subject to an M0 spike proving cancellation, operation and
-memory limits, async host calls, manifest loading, and the `AssetContext` API. Rune and Lua remain
-alternatives if that spike fails. WASM is deferred until a concrete plugin demonstrates a need for
-portable compiled components that the script profile cannot meet.
+The initial scripting engine is **Rhai**, subject to an M0 spike proving cancellation, operation/memory
+limits, async host calls, manifest loading, and the `AssetContext` API; Rune and Lua remain fallbacks.
+WASM is deferred until a concrete plugin needs portable compiled components the script profile cannot
+meet. This is **not** the rejected "hybrid" where built-ins get an unconstrained private API — all
+profiles implement identical request/result semantics and capability-specific conformance tests; only
+the transport adapter differs.
 
-Sidereal v0.1 does **not** orchestrate arbitrary plugin containers, install Python environments, or
-manage external-provider upgrades. An external provider is an explicit, user-managed dependency.
-For a Windows-only PixInsight integration, for example, Sidereal calls a separately installed Windows
-agent; from core's perspective it is an authenticated provider endpoint.
-
-This is not the rejected form of "hybrid" where built-ins get an unconstrained private API. All
-profiles implement the same request/result semantics and capability-specific conformance tests.
-Transport adapters differ. At least two built-ins must also ship through the embedded-script profile
-before that profile is declared stable; the initial candidates are tag/rename and API-based plate
-solving.
-
-## AssetContext
-
-Every invocation receives a run-scoped `AssetContext`. It is the only route from plugin code to core
-capabilities:
-
-- read approved asset metadata and facets;
-- request byte access as a read-only stream, descriptor, read-only mount, or disposable copy;
-- emit new assets and proposed facet values;
-- request core-managed rename, move, tag, and publish intents;
-- perform allowlisted HTTP requests;
-- access only manifest-declared, run-scoped secrets;
-- report logs and progress and observe cancellation.
-
-No profile receives a normal writable path into the asset store. If a legacy external tool requires a
-path, core supplies a read-only mount or disposable workspace and verifies input hashes after the run.
-Produced files are imported and hashed by core before becoming `AssetVersion` records.
-
-Host functions must cooperate with cancellation and resource limits. Script operation limits alone do
-not constrain a blocking native host call, so every host capability must have its own timeout and
-cancellation behavior.
-
-## Performance
-
-The interface is batch-oriented: an Operator receives an asset set, not one IPC call per asset.
-M0 benchmarks a representative 500+ frame session across the script and external-provider adapters.
-The benchmark informs batch sizing and streaming; it does not reopen the semantic contract.
-
-Large file bytes never cross a JSON or gRPC boundary by default. Co-located providers receive
-read-only handles or disposable paths. Remote providers use explicit streaming or provider-managed
-object transfer.
-
-## Security and trust
-
-Execution profile is not a trust level by itself. Built-in code is trusted first-party code; script
-bundles and external providers receive explicit capabilities from their manifests and installation
-approval. Authentication, endpoint trust, secret delivery, capability grants, and admin exposure are
-defined by [ADR-007](ADR-007-security-and-plugin-trust.md).
-
-## Consequences
-
-- The default Sidereal deployment remains one binary/container for built-ins and script plugins.
-- Lightweight extensions get a small, stable toolkit instead of host-language crate access.
-- Heavy integrations retain language and operating-system freedom without becoming the universal
-  plugin tax.
-- The team maintains multiple transport adapters, but one semantic contract and conformance suite.
-- A compiled built-in can still panic with core; only trusted first-party code belongs in that
-  profile.
-- WASM and container orchestration remain reversible additions rather than M0 prerequisites.
+The interface is batch-oriented (an Operator receives an asset set, not one call per asset) and large
+file bytes never cross a JSON/gRPC boundary — co-located providers get read-only handles or disposable
+paths, remote providers use explicit streaming. An M0 benchmark on a 500+ frame session sizes batching
+without reopening the semantic contract.
 
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213). Adopt the **capability-oriented hybrid** from the Recommendation:
-the three execution profiles in the table above (built-in Rust, embedded script, external provider)
-behind one semantic contract, each passing the same capability-specific conformance suite with only the
-transport differing. This is **not** the rejected "hybrid" where built-ins get an unconstrained private
-API — core keeps authority through the capability-limited `AssetContext` above; no profile gets ambient
-asset, secret, process, or network access.
+Accepted 2026-08-18 (M0 of RFC #213). Adopt the **capability-oriented hybrid** above: the three
+execution profiles behind one semantic contract, each passing the same capability-specific conformance
+suite with only the transport differing.
 
-Also decided here:
+- **`AssetContext` is the only route from plugin code to core** — approved metadata/facets, mediated
+  byte access (read-only stream, descriptor, mount, or disposable copy), emitting new assets and
+  proposed facets, core-managed rename/move/tag/publish intents, allowlisted HTTP, manifest-declared
+  run-scoped secrets, and logs/progress/cancellation. No profile gets a writable path into the store;
+  core imports and hashes produced files into `AssetVersion` records. Host capabilities each carry their
+  own timeout and cancellation. The full enumeration lives in [plugins.md](../architecture/plugins.md).
+- **Execution profile is not a trust level.** Built-in Rust is trusted first-party code; script bundles
+  and external providers get explicit capabilities at install. Authentication, grants, and secret
+  delivery are [ADR-007](ADR-007-security-and-plugin-trust.md).
+- **No published Rust dynamic ABI; WASM deferred; Rhai contingent on the M0 spike** (Rune/Lua as
+  fallbacks). v0.1 does **not** orchestrate plugin containers, provision Python environments, or manage
+  external-provider upgrades — an external provider is a user-managed dependency.
+- The embedded-script profile is declared stable only after **≥2 built-ins also ship through it**
+  (initial candidates: tag/rename and API-based plate solving).
 
-- **No published Rust dynamic ABI** — compiler ABI instability rules out third-party dylibs.
-- **Rhai** is the initial scripting engine, contingent on the M0 spike (cancellation, operation/memory
-  limits, async host calls, manifest loading, `AssetContext`); **Rune and Lua are the fallbacks** if it
-  fails. **WASM is deferred** until a concrete plugin needs compiled components the script profile can't
-  provide.
-- v0.1 does **not** orchestrate plugin containers, provision Python environments, or manage
-  external-provider upgrades — an external provider is a user-managed dependency. The embedded-script
-  profile is declared stable only after **≥2 built-ins also ship through it** (initial candidates:
-  tag/rename and API-based plate solving).
+A compiled built-in can still panic with core, so only trusted first-party code belongs in that
+profile; WASM and container orchestration remain reversible later additions, not M0 prerequisites.

--- a/docs/decisions/ADR-001-plugin-boundary.md
+++ b/docs/decisions/ADR-001-plugin-boundary.md
@@ -1,6 +1,6 @@
 # 001: Plugin Contract and Execution Profiles
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-29
 **Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The plugin contract in [docs/architecture/plugins.md](../architecture/plugins.md) defines the common semantics; this ADR chooses how different classes of plugin execute and are installed.
 
@@ -109,4 +109,30 @@ defined by [ADR-007](ADR-007-security-and-plugin-trust.md).
 
 ## Decision
 
-[Filled in after review.]
+Accepted 2026-08-18 (M0 of RFC #213). Adopt the **capability-oriented hybrid** from the
+Recommendation, with three execution profiles behind one semantic contract:
+
+- **Built-in Rust** — trusted, first-party, performance-sensitive behavior (FITS/XISF readers,
+  storage adapters, core astro Operators), compiled into the binary as crates.
+- **Embedded script** — the default public extension surface for lightweight Operators, Sources, and
+  Sinks; a manifest plus script source in a plugin bundle loaded by Sidereal.
+- **External provider** — a separately installed, user-managed service or agent for Python ML,
+  Siril/PixInsight/ASTAP, and hardware- or OS-specific tools; the manifest configures its endpoint.
+
+All three implement identical Source/Operator/Sink request-and-result semantics and pass the same
+capability-specific conformance suite; only the transport adapter differs. This is explicitly **not**
+the rejected "hybrid" in which built-ins get an unconstrained private API. Core retains authority:
+plugins request effects through a capability-limited `AssetContext` and never receive ambient asset,
+secret, process, or network access.
+
+**No published Rust dynamic ABI** — compiler ABI instability rules out third-party dylibs.
+
+The initial scripting engine is **Rhai**, contingent on an M0 spike proving cancellation, operation
+and memory limits, async host calls, manifest loading, and the `AssetContext` API; **Rune and Lua are
+the fallbacks if that spike fails.** **WASM is deferred** until a concrete plugin needs portable
+compiled components the script profile cannot provide.
+
+Sidereal v0.1 does **not** orchestrate arbitrary plugin containers, provision Python environments, or
+manage external-provider upgrades; an external provider is an explicit, user-managed dependency. The
+embedded-script profile is declared stable only after **at least two built-ins also ship through it** —
+the initial candidates are tag/rename and API-based plate solving.

--- a/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
+++ b/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The outcome constrains the [Lineage](../architecture/README.md#lineage) model and must be decided before M1 builds the core spine.
+**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The outcome constrains the [Lineage](../architecture/README.md#core-concepts) model and must be decided before M1 builds the core spine.
 
 ## Problem
 
@@ -117,37 +117,21 @@ this Decision is filled in:
 
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option C — a stable Asset plus immutable
-AssetVersion** — with the identity, revision, reconciliation, and layout rules in the Recommendation
-above. Option A (mutable surrogate) is rejected because it destroys byte history and cannot say which
-pre/post-operation bytes a self-edge used; Option B (content-hash identity) is rejected because it
-makes logical identity unstable and forces collections and external mappings to chase replacements.
+Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option C — a stable Asset plus immutable AssetVersion** —
+with the identity, revision, reconciliation, and layout rules in the Recommendation, and the #217 /
+DataHub refinements in the Note, both now part of this Decision. Option A (mutable surrogate) is
+rejected because it destroys byte history and cannot say which pre/post-operation bytes a self-edge
+used; Option B (content-hash identity) is rejected because it makes logical identity unstable and forces
+collections and external mappings to chase replacements.
 
-The identity model is settled:
-
-- `Asset.id` is a stable opaque surrogate, independent of path and content.
-- `AssetVersion.id` is an opaque identifier with a mandatory content hash (unique/indexed for
-  dedup and integrity, but not the user-facing key), byte size, format, and creation provenance.
-- Lineage edges and Operation Run inputs/outputs reference exact **AssetVersions**, not Assets.
-- Rename/move is a path event and does **not** create a version; any byte change creates a new
-  immutable version; new scientific products (thumbnails, masters, stacks, exports) are normally new
-  Assets. Core — not plugins — mints identities, hashes bytes, advances current-version pointers, and
-  writes lineage. Retention is lineage-aware: anything referenced by lineage, a run, a hold, or
-  migration audit cannot be GC'd.
-
-**Folding in the #217 / DataHub comparison** (the note above is now part of this Decision):
+Settled specifics beyond the Recommendation:
 
 - The "current" selection is a separate `Asset.current_version_id` pointer, **not** a moving `v0`
-  latest sentinel; `AssetVersion.id` is immutable so a lineage edge always denotes a fixed byte-state.
-  `isLatest` is **computed**, never a stored per-version boolean.
-- Versions carry navigation aids that are **metadata, not identity**: a dense per-Asset ordinal
-  `version_seq` plus optional curated `label` / `aliases` / `note`. Byte revisions have a canonical
-  temporal order, so no ordering-scheme abstraction is introduced.
+  sentinel; `isLatest` is **computed**, never a stored per-version boolean.
+- Navigation aids that are **metadata, not identity**: a dense per-Asset `version_seq` ordinal plus
+  optional curated `label` / `aliases` / `note`.
 - Advancing the current pointer uses **optimistic concurrency** — compare-and-swap guarded by an
-  `Asset.revision` counter — adopting DataHub's lost-update discipline.
+  `Asset.revision` counter.
 
-**Still open within this ADR, to settle before M1 (not blocking acceptance):** the exact on-disk tree
-shape and cross-filesystem move behavior, bound by the invariants listed under *Storage layout*
-(recoverable DB+FS updates, user-visible moves never rewrite content, internal historical versions
-never surface as duplicate current assets, path-traversal/symlink-escape rejected, every stored file
-reconcilable to an AssetVersion + hash).
+**Still open, to settle before M1 (not blocking acceptance):** the exact on-disk tree shape and
+cross-filesystem move behavior, bound by the *Storage layout* invariants above.

--- a/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
+++ b/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
@@ -85,17 +85,10 @@ invariants (recoverable DB+FS updates, moves never rewrite content, historical v
 duplicate current assets, path-traversal/symlink escape rejected, every file reconcilable to an
 AssetVersion + hash) and must be Accepted before M1 storage design.
 
-## Decision
+### Version navigation and concurrency (input from #217 / DataHub)
 
-Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option C — a stable Asset plus immutable AssetVersion** —
-with the identity, revision, reconciliation, and layout rules in the Recommendation. Option A (mutable
-surrogate) is rejected because it destroys byte history and cannot say which pre/post-operation bytes a
-self-edge used; Option B (content-hash identity) is rejected because it makes logical identity unstable
-and forces collections and external mappings to chase replacements.
-
-Settled specifics beyond the Recommendation (a [#217](https://github.com/sidereal-io/sidereal/issues/217)
-/ DataHub comparison confirmed the Option C shape and these deliberate divergences from DataHub's moving
-`v0` sentinel):
+A [#217](https://github.com/sidereal-io/sidereal/issues/217) / DataHub comparison confirmed the Option C
+shape, with these deliberate divergences from DataHub's moving `v0` sentinel:
 
 - The "current" selection is a separate `Asset.current_version_id` pointer, **not** a moving `v0`
   sentinel; `isLatest` is **computed**, never a stored per-version boolean.
@@ -104,6 +97,8 @@ Settled specifics beyond the Recommendation (a [#217](https://github.com/siderea
 - Advancing the current pointer uses **optimistic concurrency** — compare-and-swap guarded by an
   `Asset.revision` counter.
 
-**On-disk tree layout and cross-filesystem moves are decided separately in
-[ADR-011](ADR-011-storage-tree-layout.md) (Proposed), which gates M1.** This ADR's acceptance covers
-Asset/AssetVersion identity and versioning only.
+## Decision
+
+Accepted 2026-08-18 (M0 of RFC #213) — **Option C**, as recommended (identity and versioning only).
+On-disk tree layout and cross-filesystem moves are decided separately in
+[ADR-011](ADR-011-storage-tree-layout.md) (Proposed), which gates M1.

--- a/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
+++ b/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
@@ -90,41 +90,17 @@ before M1, with these invariants:
 - path traversal and symlink escape are rejected;
 - every stored file can be reconciled to an AssetVersion and hash.
 
-## Consequences
-
-- Stable links, collections, and source mappings survive moves and byte revisions.
-- Lineage records exact content rather than a mutable logical placeholder.
-- Byte-editing operations consume additional storage until retention safely reclaims old revisions.
-- Queries that only need the current state join Asset to its current AssetVersion.
-
-## Note: version identity and navigation (input from #217 / DataHub comparison)
-
-A comparison against DataHub's aspect-versioning and VersionSet models (see [#217](https://github.com/sidereal-io/sidereal/issues/217))
-confirms the Option C shape — a grouping identity (Asset ≈ VersionSet) plus stable-identity versioned
-members (AssetVersion ≈ versioned entity). Two divergences are deliberate and should be reflected when
-this Decision is filled in:
-
-- **Stable opaque `AssetVersion.id`, not a moving "latest" sentinel.** DataHub's `v0` re-points to new
-  content on each write, which is fine for "GET latest" but unsafe for a lineage edge that must denote a
-  fixed byte-state. Our version id is immutable; the "current" selection is a separate
-  `Asset.current_version_id` pointer, and `isLatest` is computed, never a stored per-version boolean.
-- **Navigation aids that are not identity:** a dense per-Asset ordinal (`version_seq`) plus optional
-  curated `label`/`aliases`/`note` on a version. These make versions human-navigable without exposing
-  UUIDs; they are metadata, not identity, and carry no ordering-scheme abstraction (byte revisions have a
-  canonical temporal order).
-- **Optimistic concurrency on current-pointer advance** (compare-and-swap via an `Asset.revision` guard),
-  adopting DataHub's lost-update discipline.
-
 ## Decision
 
 Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option C — a stable Asset plus immutable AssetVersion** —
-with the identity, revision, reconciliation, and layout rules in the Recommendation, and the #217 /
-DataHub refinements in the Note, both now part of this Decision. Option A (mutable surrogate) is
-rejected because it destroys byte history and cannot say which pre/post-operation bytes a self-edge
-used; Option B (content-hash identity) is rejected because it makes logical identity unstable and forces
-collections and external mappings to chase replacements.
+with the identity, revision, reconciliation, and layout rules in the Recommendation. Option A (mutable
+surrogate) is rejected because it destroys byte history and cannot say which pre/post-operation bytes a
+self-edge used; Option B (content-hash identity) is rejected because it makes logical identity unstable
+and forces collections and external mappings to chase replacements.
 
-Settled specifics beyond the Recommendation:
+Settled specifics beyond the Recommendation (a [#217](https://github.com/sidereal-io/sidereal/issues/217)
+/ DataHub comparison confirmed the Option C shape and these deliberate divergences from DataHub's moving
+`v0` sentinel):
 
 - The "current" selection is a separate `Asset.current_version_id` pointer, **not** a moving `v0`
   sentinel; `isLatest` is **computed**, never a stored per-version boolean.

--- a/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
+++ b/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
@@ -1,6 +1,6 @@
 # 003: Storage Layout, Asset Identity, and Content Revisions
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-29
 **Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The outcome constrains the [Lineage](../architecture/README.md#lineage) model and must be decided before M1 builds the core spine.
 
@@ -97,6 +97,57 @@ before M1, with these invariants:
 - Byte-editing operations consume additional storage until retention safely reclaims old revisions.
 - Queries that only need the current state join Asset to its current AssetVersion.
 
+## Note: version identity and navigation (input from #217 / DataHub comparison)
+
+A comparison against DataHub's aspect-versioning and VersionSet models (see [#217](https://github.com/sidereal-io/sidereal/issues/217))
+confirms the Option C shape — a grouping identity (Asset ≈ VersionSet) plus stable-identity versioned
+members (AssetVersion ≈ versioned entity). Two divergences are deliberate and should be reflected when
+this Decision is filled in:
+
+- **Stable opaque `AssetVersion.id`, not a moving "latest" sentinel.** DataHub's `v0` re-points to new
+  content on each write, which is fine for "GET latest" but unsafe for a lineage edge that must denote a
+  fixed byte-state. Our version id is immutable; the "current" selection is a separate
+  `Asset.current_version_id` pointer, and `isLatest` is computed, never a stored per-version boolean.
+- **Navigation aids that are not identity:** a dense per-Asset ordinal (`version_seq`) plus optional
+  curated `label`/`aliases`/`note` on a version. These make versions human-navigable without exposing
+  UUIDs; they are metadata, not identity, and carry no ordering-scheme abstraction (byte revisions have a
+  canonical temporal order).
+- **Optimistic concurrency on current-pointer advance** (compare-and-swap via an `Asset.revision` guard),
+  adopting DataHub's lost-update discipline.
+
 ## Decision
 
-[Filled in after review.]
+Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option C — a stable Asset plus immutable
+AssetVersion** — with the identity, revision, reconciliation, and layout rules in the Recommendation
+above. Option A (mutable surrogate) is rejected because it destroys byte history and cannot say which
+pre/post-operation bytes a self-edge used; Option B (content-hash identity) is rejected because it
+makes logical identity unstable and forces collections and external mappings to chase replacements.
+
+The identity model is settled:
+
+- `Asset.id` is a stable opaque surrogate, independent of path and content.
+- `AssetVersion.id` is an opaque identifier with a mandatory content hash (unique/indexed for
+  dedup and integrity, but not the user-facing key), byte size, format, and creation provenance.
+- Lineage edges and Operation Run inputs/outputs reference exact **AssetVersions**, not Assets.
+- Rename/move is a path event and does **not** create a version; any byte change creates a new
+  immutable version; new scientific products (thumbnails, masters, stacks, exports) are normally new
+  Assets. Core — not plugins — mints identities, hashes bytes, advances current-version pointers, and
+  writes lineage. Retention is lineage-aware: anything referenced by lineage, a run, a hold, or
+  migration audit cannot be GC'd.
+
+**Folding in the #217 / DataHub comparison** (the note above is now part of this Decision):
+
+- The "current" selection is a separate `Asset.current_version_id` pointer, **not** a moving `v0`
+  latest sentinel; `AssetVersion.id` is immutable so a lineage edge always denotes a fixed byte-state.
+  `isLatest` is **computed**, never a stored per-version boolean.
+- Versions carry navigation aids that are **metadata, not identity**: a dense per-Asset ordinal
+  `version_seq` plus optional curated `label` / `aliases` / `note`. Byte revisions have a canonical
+  temporal order, so no ordering-scheme abstraction is introduced.
+- Advancing the current pointer uses **optimistic concurrency** — compare-and-swap guarded by an
+  `Asset.revision` counter — adopting DataHub's lost-update discipline.
+
+**Still open within this ADR, to settle before M1 (not blocking acceptance):** the exact on-disk tree
+shape and cross-filesystem move behavior, bound by the invariants listed under *Storage layout*
+(recoverable DB+FS updates, user-visible moves never rewrite content, internal historical versions
+never surface as duplicate current assets, path-traversal/symlink-escape rejected, every stored file
+reconcilable to an AssetVersion + hash).

--- a/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
+++ b/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
@@ -79,16 +79,11 @@ file can be re-associated by hash and additional safety checks.
 
 ### Storage layout
 
-Identity does not prescribe layout. Originals may appear in a user-meaningful tree by target, session,
-and date, while derived renditions and superseded versions may live in a protected internal subtree.
-The exact tree and cross-filesystem move behavior remain open within this ADR and must be settled
-before M1, with these invariants:
-
-- database and filesystem updates are recoverable after interruption;
-- a user-visible move never rewrites content;
-- internal historical versions are not presented as duplicate current assets;
-- path traversal and symlink escape are rejected;
-- every stored file can be reconciled to an AssetVersion and hash.
+Identity does not prescribe layout. The exact on-disk tree and cross-filesystem move behavior are a
+separate decision — split out to [ADR-011](ADR-011-storage-tree-layout.md), which carries the binding
+invariants (recoverable DB+FS updates, moves never rewrite content, historical versions never surface as
+duplicate current assets, path-traversal/symlink escape rejected, every file reconcilable to an
+AssetVersion + hash) and must be Accepted before M1 storage design.
 
 ## Decision
 
@@ -109,5 +104,6 @@ Settled specifics beyond the Recommendation (a [#217](https://github.com/siderea
 - Advancing the current pointer uses **optimistic concurrency** — compare-and-swap guarded by an
   `Asset.revision` counter.
 
-**Still open, to settle before M1 (not blocking acceptance):** the exact on-disk tree shape and
-cross-filesystem move behavior, bound by the *Storage layout* invariants above.
+**On-disk tree layout and cross-filesystem moves are decided separately in
+[ADR-011](ADR-011-storage-tree-layout.md) (Proposed), which gates M1.** This ADR's acceptance covers
+Asset/AssetVersion identity and versioning only.

--- a/docs/decisions/ADR-004-database-engine-and-schema.md
+++ b/docs/decisions/ADR-004-database-engine-and-schema.md
@@ -1,6 +1,6 @@
 # 004: Database Engine and Schema Strategy
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-29
 **Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The [facet mechanism](../architecture/README.md#the-mechanism-metadata-facets) imposes concrete requirements on the store; this ADR picks the engine and schema approach that satisfy them.
 
@@ -64,4 +64,39 @@ Also decide here:
 
 ## Decision
 
-[Filled in after review.]
+Accepted 2026-08-18 (M0 of RFC #213). **Option C — PostgreSQL-only.**
+
+This **reverses both** the RFC's original leaning (Option B) and this ADR's own Recommendation (which
+argued for Option A). The reversal is deliberate. A single server-grade engine gives the strongest
+facet indexing (JSONB + GIN over the semi-structured facet values calibration-master matching depends
+on), the best recursive-CTE performance for lineage traversal, and real concurrency under bursty
+ingest. Committing to one dialect also eliminates the entire class of problems the analysis package
+flagged — unverified SQLite/Postgres parity (`Q1`), silent dialect divergence, a drifted migration
+snapshot chain, and doubled facet-indexing work where JSON1 and JSONB/GIN diverge most. Neither a
+dual-dialect matrix (B) nor a SQLite feature-set ceiling (A) is carried into v2.
+
+**Deployment trade-off, and its mitigation.** Option C's rejection ground was that it "forces every
+single-user self-hoster to run a database server, directly against the deployment story that makes
+Sidereal easy to adopt." We accept that cost and neutralize it at the packaging layer rather than the
+schema layer: v2 ships an **all-in-one Docker image** (Postgres provisioned and managed inside the
+container) and/or a **docker-compose bundle** that stands Postgres up alongside the app. The
+single-user install stays effectively one command, and the M6 cutover requirements — port 5000, volume
+mounts, PUID/PGID, healthcheck — are preserved, with the data volume now backing Postgres rather than a
+SQLite file. Backup documentation must cover the Postgres volume (and `pg_dump` guidance) in place of
+the old file copy.
+
+**Coupled calls settled here** (the ADR flagged these for the same decision):
+
+- **Facet storage:** facets live in **JSONB columns with GIN indexes**, not a key-value side table.
+  The JSON-column approach reads better and leans on dialect-specific features — which the ADR noted is
+  "only safe once the dialect question above is settled," and it now is.
+- **ORM / query layer:** **`sqlx`.** Facet queries are dynamic, which argues against compile-time
+  query builders (`diesel`, `SeaORM`); `sqlx` provides async Postgres access with runtime-composed SQL
+  and optional compile-time query checking where the query is static.
+- **Migrations:** **forward-only.** Downgrade is explicitly **unsupported** and guarded against (a
+  newer schema version refuses to start against an older binary), removing v0.10.x's undefined
+  downgrade behavior (`U2`). A single canonical migration chain replaces the two hand-maintained schema
+  files.
+
+**Existing Postgres and SQLite users** both reach v2 through the one-way v0.10.x importer (RFC / ADR-003
+reconciliation), not through in-place dialect migration.

--- a/docs/decisions/ADR-004-database-engine-and-schema.md
+++ b/docs/decisions/ADR-004-database-engine-and-schema.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The [facet mechanism](../architecture/README.md#the-mechanism-metadata-facets) imposes concrete requirements on the store; this ADR picks the engine and schema approach that satisfy them.
+**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The [facet mechanism](../architecture/README.md#core-and-domain-packs) imposes concrete requirements on the store; this ADR picks the engine and schema approach that satisfy them.
 
 ## Problem
 
@@ -64,39 +64,30 @@ Also decide here:
 
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213). **Option C — PostgreSQL-only.**
+Accepted 2026-08-18 (M0 of RFC #213). **Option C — PostgreSQL-only.** This **reverses both** the RFC's
+leaning (B) and this ADR's own Recommendation (A) — deliberately. One server-grade engine gives the
+strongest facet indexing (JSONB + GIN), the best recursive-CTE performance for lineage, and real
+concurrency under bursty ingest, and it eliminates the whole class of problems the analysis package
+flagged: unverified SQLite/Postgres parity (`Q1`), silent dialect divergence, a drifted migration chain,
+and doubled facet-indexing work. Neither a dual-dialect matrix (B) nor a SQLite ceiling (A) is carried
+into v2.
 
-This **reverses both** the RFC's original leaning (Option B) and this ADR's own Recommendation (which
-argued for Option A). The reversal is deliberate. A single server-grade engine gives the strongest
-facet indexing (JSONB + GIN over the semi-structured facet values calibration-master matching depends
-on), the best recursive-CTE performance for lineage traversal, and real concurrency under bursty
-ingest. Committing to one dialect also eliminates the entire class of problems the analysis package
-flagged — unverified SQLite/Postgres parity (`Q1`), silent dialect divergence, a drifted migration
-snapshot chain, and doubled facet-indexing work where JSON1 and JSONB/GIN diverge most. Neither a
-dual-dialect matrix (B) nor a SQLite feature-set ceiling (A) is carried into v2.
+**Deployment trade-off, mitigated at the packaging layer.** Option C's rejection ground was that it
+forces every self-hoster to run a database server. We accept that and neutralize it in packaging, not
+schema: v2 ships an **all-in-one Docker image** and/or a **docker-compose bundle** that stands Postgres
+up alongside the app. The install stays effectively one command; M6 requirements (port 5000, volume
+mounts, PUID/PGID, healthcheck) are preserved, with the data volume now backing Postgres. Backup docs
+cover the Postgres volume and `pg_dump` in place of the old file copy.
 
-**Deployment trade-off, and its mitigation.** Option C's rejection ground was that it "forces every
-single-user self-hoster to run a database server, directly against the deployment story that makes
-Sidereal easy to adopt." We accept that cost and neutralize it at the packaging layer rather than the
-schema layer: v2 ships an **all-in-one Docker image** (Postgres provisioned and managed inside the
-container) and/or a **docker-compose bundle** that stands Postgres up alongside the app. The
-single-user install stays effectively one command, and the M6 cutover requirements — port 5000, volume
-mounts, PUID/PGID, healthcheck — are preserved, with the data volume now backing Postgres rather than a
-SQLite file. Backup documentation must cover the Postgres volume (and `pg_dump` guidance) in place of
-the old file copy.
+**Coupled calls settled here:**
 
-**Coupled calls settled here** (the ADR flagged these for the same decision):
+- **Facet storage:** **JSONB columns with GIN indexes**, not a key-value side table.
+- **ORM / query layer:** **`sqlx`** — facet queries are dynamic, arguing against compile-time builders
+  (`diesel`, `SeaORM`); `sqlx` gives async Postgres with runtime-composed SQL and optional compile-time
+  checking for static queries.
+- **Migrations:** **forward-only**, downgrade **unsupported** and guarded (a newer schema refuses to
+  start against an older binary), removing `U2`. One canonical migration chain replaces the two
+  hand-maintained schema files.
 
-- **Facet storage:** facets live in **JSONB columns with GIN indexes**, not a key-value side table.
-  The JSON-column approach reads better and leans on dialect-specific features — which the ADR noted is
-  "only safe once the dialect question above is settled," and it now is.
-- **ORM / query layer:** **`sqlx`.** Facet queries are dynamic, which argues against compile-time
-  query builders (`diesel`, `SeaORM`); `sqlx` provides async Postgres access with runtime-composed SQL
-  and optional compile-time query checking where the query is static.
-- **Migrations:** **forward-only.** Downgrade is explicitly **unsupported** and guarded against (a
-  newer schema version refuses to start against an older binary), removing v0.10.x's undefined
-  downgrade behavior (`U2`). A single canonical migration chain replaces the two hand-maintained schema
-  files.
-
-**Existing Postgres and SQLite users** both reach v2 through the one-way v0.10.x importer (RFC / ADR-003
-reconciliation), not through in-place dialect migration.
+Existing Postgres and SQLite users both reach v2 through the one-way v0.10.x importer, not in-place
+dialect migration.

--- a/docs/decisions/ADR-007-security-and-plugin-trust.md
+++ b/docs/decisions/ADR-007-security-and-plugin-trust.md
@@ -99,36 +99,16 @@ M1 cannot begin until:
 ## Decision
 
 Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option B — built-in single-user authentication and
-explicit plugin grants** — as specified in the Recommendation. The trusted-network model (Option A) is
-rejected because file mutation and plugin management cannot be handed to any network caller; full
-multi-user RBAC (Option C) is deferred as an Immich-like sharing surface the architecture does not
-fund for v2.0.
+explicit plugin grants** — exactly as detailed in the Recommendation (application boundary, plugin trust
+and capabilities, secrets and audit). Option A (trusted network) is rejected because file mutation and
+plugin management cannot be handed to any network caller; Option C (full RBAC) is deferred as an
+Immich-like sharing surface v2.0 does not fund.
 
-**Application boundary.** Initial setup creates or imports one administrator credential; there is no
-unauthenticated mutation mode. Browser access uses secure, HTTP-only, same-site sessions; state-changing
-HTTP requests carry a CSRF token. CORS is deny-by-default with exact-match configured origins, never a
-credentialed wildcard. WebSocket auth derives from the same session and rechecks expiry/revocation. A
-read-only public gallery, if added, is a separate explicitly-enabled surface with no admin API
-reachability. Reverse-proxy trusted-header auth may come later as an explicit mode with a configured
-proxy allowlist — never by accepting arbitrary identity headers.
+The load-bearing invariants: no unauthenticated mutation mode (setup mints one admin credential); secure
+HTTP-only same-site sessions with CSRF on state-changing requests; deny-by-default exact-match CORS,
+never a credentialed wildcard; session-derived WebSocket auth; plugins get no ambient
+environment/process/network/database/asset access and only manifest-declared, admin-approved grants;
+external providers authenticate per-instance over TLS/mTLS with run-ID-checked callbacks; secrets
+encrypted at rest, never re-read, redacted everywhere, and all trust-relevant events audited.
 
-**Plugin trust and capabilities.** Built-in Rust is trusted first-party code under the release threat
-model. Script bundles and external providers are untrusted by default; installation displays and
-records requested capabilities (byte access, facet writes, network destinations, secret names,
-core-managed mutations). Grant changes require administrator confirmation and invalidate active plugin
-sessions. Plugins have no ambient environment, process, network, database, or asset-store access.
-External providers authenticate with a plugin-instance credential over TLS, mTLS, or a protected local
-transport, with identity pinned to the configured instance; callbacks carry the run ID and are rejected
-on any run/provider/grant mismatch.
-
-**Secrets and audit.** Secrets are encrypted at rest with deployment-managed key material and are never
-returned through read APIs after creation. A run receives only its declared secrets, scoped to the
-plugin instance, redacted from logs, errors, progress payloads, and history. Plugin install, grant,
-revoke, secret access, provider connection, file mutation, and publish events are auditable. Backup and
-migration docs state how encrypted secrets and key material are handled.
-
-The **M0 exit criteria** above are binding: M1 cannot begin until the authentication mode and setup
-flow are selected; HTTP/WebSocket/CORS/CSRF behavior is specified and integration-tested; the manifest
-grant vocabulary and approval flow are defined; external-provider auth and secret redaction have
-testable fixtures; and the threat model covers a malicious script, a compromised provider, and an
-unauthenticated network caller.
+The **M0 exit criteria** above are binding — M1 cannot begin until all five are met.

--- a/docs/decisions/ADR-007-security-and-plugin-trust.md
+++ b/docs/decisions/ADR-007-security-and-plugin-trust.md
@@ -1,6 +1,6 @@
 # 007: Security and Plugin Trust Model
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-30
 **Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). v2 adds filesystem mutation, plugin execution, external providers, and scoped secret delivery. The current unauthenticated/CORS-open deployment posture cannot be carried forward implicitly.
 
@@ -98,4 +98,37 @@ M1 cannot begin until:
 
 ## Decision
 
-[Filled in after review.]
+Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option B — built-in single-user authentication and
+explicit plugin grants** — as specified in the Recommendation. The trusted-network model (Option A) is
+rejected because file mutation and plugin management cannot be handed to any network caller; full
+multi-user RBAC (Option C) is deferred as an Immich-like sharing surface the architecture does not
+fund for v2.0.
+
+**Application boundary.** Initial setup creates or imports one administrator credential; there is no
+unauthenticated mutation mode. Browser access uses secure, HTTP-only, same-site sessions; state-changing
+HTTP requests carry a CSRF token. CORS is deny-by-default with exact-match configured origins, never a
+credentialed wildcard. WebSocket auth derives from the same session and rechecks expiry/revocation. A
+read-only public gallery, if added, is a separate explicitly-enabled surface with no admin API
+reachability. Reverse-proxy trusted-header auth may come later as an explicit mode with a configured
+proxy allowlist — never by accepting arbitrary identity headers.
+
+**Plugin trust and capabilities.** Built-in Rust is trusted first-party code under the release threat
+model. Script bundles and external providers are untrusted by default; installation displays and
+records requested capabilities (byte access, facet writes, network destinations, secret names,
+core-managed mutations). Grant changes require administrator confirmation and invalidate active plugin
+sessions. Plugins have no ambient environment, process, network, database, or asset-store access.
+External providers authenticate with a plugin-instance credential over TLS, mTLS, or a protected local
+transport, with identity pinned to the configured instance; callbacks carry the run ID and are rejected
+on any run/provider/grant mismatch.
+
+**Secrets and audit.** Secrets are encrypted at rest with deployment-managed key material and are never
+returned through read APIs after creation. A run receives only its declared secrets, scoped to the
+plugin instance, redacted from logs, errors, progress payloads, and history. Plugin install, grant,
+revoke, secret access, provider connection, file mutation, and publish events are auditable. Backup and
+migration docs state how encrypted secrets and key material are handled.
+
+The **M0 exit criteria** above are binding: M1 cannot begin until the authentication mode and setup
+flow are selected; HTTP/WebSocket/CORS/CSRF behavior is specified and integration-tested; the manifest
+grant vocabulary and approval flow are defined; external-provider auth and secret redaction have
+testable fixtures; and the threat model covers a malicious script, a compromised provider, and an
+unauthenticated network caller.

--- a/docs/decisions/ADR-007-security-and-plugin-trust.md
+++ b/docs/decisions/ADR-007-security-and-plugin-trust.md
@@ -2,92 +2,88 @@
 
 **Status:** Accepted
 **Date:** 2026-07-30
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). v2 adds filesystem mutation, plugin execution, external providers, and scoped secret delivery. The current unauthenticated/CORS-open deployment posture cannot be carried forward implicitly.
+**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). v2 adds filesystem
+mutation, plugin execution, external providers, and scoped secret delivery. The current
+unauthenticated/CORS-open posture cannot be carried forward implicitly.
 
 ## Problem
 
-Sidereal v2 becomes the system of record for user files and can invoke code that reads assets,
-publishes externally, and requests secrets. Before M1 touches a real filesystem, the architecture
-must define:
-
-- who may use the HTTP and WebSocket APIs;
-- which actions require elevated authority;
-- whether a plugin is trusted and which capabilities it receives;
-- how external-provider endpoints are authenticated;
-- how secrets are stored, delivered, logged, and revoked;
-- which browser origins can issue authenticated requests.
-
-Treating every self-hosted network as trusted is not sufficient. Reverse proxies, shared home
-networks, browser-based CSRF, and accidentally exposed container ports are ordinary deployment
-conditions.
+v2 becomes the system of record for user files and can invoke code that reads assets, publishes
+externally, and requests secrets. Before M1 touches a real filesystem, the architecture must define who
+may use the HTTP and WebSocket APIs, which actions need elevated authority, whether a plugin is trusted
+and which capabilities it receives, how external-provider endpoints authenticate, how secrets are
+stored/delivered/logged/revoked, and which browser origins may issue authenticated requests. Treating
+every self-hosted network as trusted is not sufficient — reverse proxies, shared home networks,
+browser-based CSRF, and accidentally exposed container ports are ordinary conditions.
 
 ## Options
 
 ### Option A: Preserve the trusted-network model
 
-No built-in authentication; operators are responsible for a reverse proxy and network isolation.
-
-This is simple, but it gives any network caller file-mutation and plugin-management authority and
-leaves secure WebSocket and browser behavior deployment-specific.
+No built-in authentication; operators supply a reverse proxy and network isolation. Simple, but it
+hands any network caller file-mutation and plugin-management authority and leaves secure WebSocket and
+browser behavior deployment-specific.
 
 ### Option B: Built-in single-user authentication and explicit plugin grants
 
-Sidereal owns one administrative identity initially, authenticated browser sessions, CSRF protection,
-restricted origins, and per-install plugin capability approval. Multi-user roles can be added later.
-
-This fits the single-user product while establishing an enforceable trust boundary.
+One administrative identity, authenticated browser sessions, CSRF protection, restricted origins, and
+per-install plugin capability approval. Multi-user roles can come later. Fits the single-user product
+while establishing an enforceable trust boundary.
 
 ### Option C: Full multi-user RBAC in v2.0
 
-Model administrators, editors, viewers, plugin managers, and per-collection grants before cutover.
-
-This is the broadest design but funds an Immich-like sharing surface the architecture explicitly
-defers.
+Administrators, editors, viewers, plugin managers, and per-collection grants before cutover. The
+broadest design, but funds an Immich-like sharing surface the architecture explicitly defers.
 
 ## Recommendation
 
-Choose **Option B** for v2.0.
+**Option B** — it fits the single-user product and establishes an enforceable boundary, where A hands
+file-mutation authority to any network caller and C funds a multi-user sharing surface v2.0 does not
+need.
 
-### Application boundary
+## Decision
 
-- Initial setup creates or imports one administrator credential; there is no unauthenticated
-  mutation mode.
-- Browser access uses secure, HTTP-only, same-site sessions. State-changing HTTP requests require a
-  CSRF token.
-- CORS is deny-by-default. Configured origins are exact matches; credentials are never combined with
-  a wildcard origin.
-- WebSocket authentication derives from the same session and rechecks expiry/revocation.
-- Read-only public gallery access, if added, is a separate explicitly enabled surface with no admin
-  API reachability.
-- Reverse-proxy authentication may be supported later as an explicit trusted-header mode with a
-  configured proxy allowlist, never by accepting arbitrary identity headers.
+Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option B — built-in single-user authentication and
+explicit plugin grants**. Option A is rejected because file mutation and plugin management cannot be
+handed to any network caller; Option C is deferred as an Immich-like sharing surface v2.0 does not fund.
 
-### Plugin trust and capabilities
+**Application boundary.**
 
-- Built-in Rust code is trusted first-party code and is covered by the release threat model.
-- Script bundles and external providers are untrusted by default. Installation displays and records
-  requested capabilities: byte access, facet writes, network destinations, secret names, and
-  core-managed mutations.
+- Initial setup creates or imports one administrator credential; there is no unauthenticated mutation
+  mode.
+- Browser access uses secure, HTTP-only, same-site sessions; state-changing HTTP requests carry a CSRF
+  token.
+- CORS is deny-by-default with exact-match configured origins; credentials are never combined with a
+  wildcard origin.
+- WebSocket auth derives from the same session and rechecks expiry/revocation.
+- A read-only public gallery, if added, is a separate explicitly-enabled surface with no admin-API
+  reachability.
+- Reverse-proxy trusted-header auth may come later as an explicit mode with a configured proxy
+  allowlist — never by accepting arbitrary identity headers.
+
+**Plugin trust and capabilities.**
+
+- Built-in Rust is trusted first-party code under the release threat model. Script bundles and external
+  providers are untrusted by default; installation displays and records requested capabilities (byte
+  access, facet writes, network destinations, secret names, core-managed mutations).
 - Grant changes require administrator confirmation and invalidate active plugin sessions.
 - Plugins have no ambient environment, process, network, database, or asset-store access.
-- External providers authenticate with a plugin-instance credential over TLS, mutually authenticated
-  TLS, or a protected local transport. Provider identity is pinned to its configured instance.
-- External-provider callbacks carry the run ID and are rejected if the run, provider, or grant does
-  not match.
+- External providers authenticate with a plugin-instance credential over TLS, mTLS, or a protected
+  local transport, identity pinned to the configured instance; callbacks carry the run ID and are
+  rejected on any run/provider/grant mismatch.
 
-### Secrets and audit
+**Secrets and audit.**
 
-- Secrets are encrypted at rest using deployment-managed key material and are never returned through
-  normal read APIs after creation.
-- A run receives only declared secrets, scoped to the plugin instance. Secrets are redacted from
-  logs, errors, progress payloads, and operation history.
-- Plugin install, grant, revoke, secret access, provider connection, file mutation, and publish
-  events are auditable.
-- Backup and migration documentation states how encrypted secrets and key material are handled.
+- Secrets are encrypted at rest with deployment-managed key material and never returned through read
+  APIs after creation.
+- A run receives only its declared secrets, scoped to the plugin instance, redacted from logs, errors,
+  progress payloads, and history.
+- Plugin install, grant, revoke, secret access, provider connection, file mutation, and publish events
+  are auditable. Backup and migration docs state how encrypted secrets and key material are handled.
 
 ## M0 exit criteria
 
-M1 cannot begin until:
+Binding — M1 cannot begin until:
 
 1. the application authentication mode and initial-setup flow are selected;
 2. HTTP, WebSocket, CORS, and CSRF behavior are specified and covered by integration tests;
@@ -95,20 +91,3 @@ M1 cannot begin until:
 4. external-provider authentication and secret redaction have testable protocol fixtures;
 5. the threat model covers a malicious script, a compromised provider, and an unauthenticated network
    caller.
-
-## Decision
-
-Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option B — built-in single-user authentication and
-explicit plugin grants** — exactly as detailed in the Recommendation (application boundary, plugin trust
-and capabilities, secrets and audit). Option A (trusted network) is rejected because file mutation and
-plugin management cannot be handed to any network caller; Option C (full RBAC) is deferred as an
-Immich-like sharing surface v2.0 does not fund.
-
-The load-bearing invariants: no unauthenticated mutation mode (setup mints one admin credential); secure
-HTTP-only same-site sessions with CSRF on state-changing requests; deny-by-default exact-match CORS,
-never a credentialed wildcard; session-derived WebSocket auth; plugins get no ambient
-environment/process/network/database/asset access and only manifest-declared, admin-approved grants;
-external providers authenticate per-instance over TLS/mTLS with run-ID-checked callbacks; secrets
-encrypted at rest, never re-read, redacted everywhere, and all trust-relevant events audited.
-
-The **M0 exit criteria** above are binding — M1 cannot begin until all five are met.

--- a/docs/decisions/ADR-007-security-and-plugin-trust.md
+++ b/docs/decisions/ADR-007-security-and-plugin-trust.md
@@ -37,15 +37,9 @@ broadest design, but funds an Immich-like sharing surface the architecture expli
 
 ## Recommendation
 
-**Option B** — it fits the single-user product and establishes an enforceable boundary, where A hands
-file-mutation authority to any network caller and C funds a multi-user sharing surface v2.0 does not
-need.
-
-## Decision
-
-Accepted 2026-08-18 (M0 of RFC #213). Adopt **Option B — built-in single-user authentication and
-explicit plugin grants**. Option A is rejected because file mutation and plugin management cannot be
-handed to any network caller; Option C is deferred as an Immich-like sharing surface v2.0 does not fund.
+**Option B — built-in single-user authentication and explicit plugin grants.** It fits the single-user
+product and establishes an enforceable boundary, where A hands file-mutation authority to any network
+caller and C funds a multi-user sharing surface v2.0 does not need. The requirements:
 
 **Application boundary.**
 
@@ -80,6 +74,11 @@ handed to any network caller; Option C is deferred as an Immich-like sharing sur
   progress payloads, and history.
 - Plugin install, grant, revoke, secret access, provider connection, file mutation, and publish events
   are auditable. Backup and migration docs state how encrypted secrets and key material are handled.
+
+## Decision
+
+Accepted 2026-08-18 (M0 of RFC #213) — **Option B**, as recommended. The M0 exit criteria below are
+binding.
 
 ## M0 exit criteria
 

--- a/docs/decisions/ADR-008-facet-schema-and-write-authority.md
+++ b/docs/decisions/ADR-008-facet-schema-and-write-authority.md
@@ -3,162 +3,91 @@
 **Status:** Accepted
 **Date:** 2026-08-01
 **Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). Selectors need a
-portable metadata contract, while domain packs and alternative plugins need interoperable typed
-values.
+portable metadata contract, while domain packs and alternative plugins need interoperable typed values.
 
 ## Problem
 
-Sidereal needs simple operational classification, rich astrophotography facts, and a small set of
-fields shared by every Asset. Maintaining both untyped labels and typed facets creates two ways to
-represent selectable metadata, requires rules for choosing between them, and invites duplication.
+Sidereal needs a small set of fields shared by every Asset plus an extensible way to carry rich, typed
+astrophotography facts. Maintaining both untyped labels and typed facets would create two ways to
+represent selectable metadata and invite duplication. The architecture needs one canonical boundary:
+which fields every Asset has, what belongs in an extensible facet, where each value is scoped, and who
+may write it — without coupling Selectors to whichever plugin produced a value.
 
-The architecture therefore needs one canonical boundary: which fields every Asset has, what belongs
-in an extensible facet, where each value is scoped, and who may write it. It must also prevent
-Selectors from becoming unnecessarily coupled to whichever plugin produced a value.
+(Backstage separates a common entity envelope from kind-specific `spec`/`status`; Sidereal borrows that
+split but makes facets its single extension mechanism, so it does not also add labels. See the
+[Backstage descriptor format](https://backstage.io/docs/features/software-catalog/descriptor-format/).)
 
-Backstage usefully separates a common entity envelope (`apiVersion`, `kind`, and common metadata such
-as `name`, optional `namespace`, UID, and labels) from kind-specific `spec` and `status`. Sidereal
-borrows the envelope/type-specific-data separation, not every field: facets are its single extension
-mechanism in M0, so it does not also add labels. See the
-[Backstage descriptor format](https://backstage.io/docs/features/software-catalog/descriptor-format/).
+## Options
 
-## Common Asset envelope
-
-Every Asset has a small core-owned envelope:
-
-| Field | Scope and semantics |
-|---|---|
-| `id` | Stable opaque Asset identity. Names, paths, Sources, and external IDs never determine it. |
-| `kind` | One normalized discriminator from a domain pack vocabulary, such as `astro.light`. |
-| `name` | Mutable display name. It is not required to be unique and is not the filesystem path. |
-
-`namespace` is deliberately omitted until Sidereal has a concrete ownership or tenancy boundary that
-Sources and Collections cannot express. Adding it later does not change opaque Asset IDs. Sidereal
-also does not need a descriptor `apiVersion`: database migrations and independently versioned plugin
-and facet contracts own schema evolution.
-
-Paths are mutable storage state. External IDs are scoped Source relationships. Neither belongs in the
-identity envelope.
-
-## Facets are the extension metadata
-
-Every additional selectable value is a namespaced facet. A facet schema declares:
-
-- scalar or structured type, units, nullability, and validation constraints;
-- scope: Asset, AssetVersion, or immutable Collection snapshot;
-- mutability and invalidation rules;
-- schema owner and producer grant requirements;
-- index and query hints;
-- schema version and compatible migration rules.
-
-Facets may express mutable intent as well as observed or derived facts. The schema keeps those uses
-precise:
-
-| Example | Scope | Semantics |
-|---|---|---|
-| `core.processing.mode=auto` | Asset, mutable | User or Source-configured processing intent |
-| `astro.fits.exptime=300 s` | AssetVersion, observed | Typed value extracted from exact bytes |
-| `astro.solve.ra=10.6847°` | AssetVersion, derived | Typed result produced by a solver |
-| `astro.session.integration=12 h` | Collection snapshot, derived | Aggregate over fixed membership |
-
-Raw evidence and a normalized decision remain different facts: `astro.fits.image_type=LIGHT` may be
-retained as an observed facet while the classifier sets the envelope `kind=astro.light`.
-
-## Selector portability
-
-Selectors reference facet schema names, not producer plugins. To keep built-in behavior portable:
-
-- schemas used by built-in policies are owned by core or the relevant domain pack;
-- alternative plugins receive grants to produce the same canonical schemas;
-- plugin-owned schemas remain selectable for deliberate plugin-specific policies, but the UI exposes
-  the dependency and a missing schema makes the policy explicitly `blocked`;
-- values are never copied into a second metadata mechanism merely to make them selectable.
-
-This means an Astrometry.net and an ASTAP Operator can both satisfy a policy selecting or requiring
-`astro.solve.*`; the policy does not depend on either implementation.
-
-## Write authority
-
-Core is the only component that persists envelope or facet changes. Plugins propose changes through
-their capability-limited `AssetContext`:
-
-- A domain pack owns its `kind` vocabulary. Sources may set a configured default or propose a
-  detected kind within their grants.
-- Users and Source configuration may set mutable facets through the same schema validation and audit
-  path as plugins.
-- One pack owns each facet schema. Compatible producer plugins request grants to write values that
-  conform to it.
-
-Schema definition and facet write authority are separate concerns. If the astro pack owns
-`astro.solve.ra`, an ASTAP Operator must be able to publish canonical solve results without either
-claiming the schema or inventing an incompatible namespace.
-
-## Facet schema options
+The envelope-plus-facets shape is not contested; the open choice is **facet ownership**.
 
 ### Option A: Producer-owned namespaces
 
-Every producer defines its own values, such as `astrometry.ra` and `astap.ra`.
-
-This avoids grants but forces every Selector, query, and UI to understand provider-specific
-alternatives.
+Every producer defines its own values (`astrometry.ra`, `astap.ra`). Avoids grants, but forces every
+Selector, query, and UI to understand provider-specific alternatives.
 
 ### Option B: Shared declaration by convention
 
-Multiple plugins may declare the same facet if their definitions happen to match.
-
-This fails at schema evolution: load order and superficially similar declarations cannot establish
-which definition is canonical.
+Multiple plugins may declare the same facet if their definitions happen to match. Fails at schema
+evolution — load order and superficially similar declarations cannot establish which is canonical.
 
 ### Option C: Exclusive schema owner with explicit producer grants
 
-One pack owns each schema. Compatible producers request write grants and values retain producer
-provenance.
-
-This preserves canonical queries while allowing competing implementations.
+One pack owns each schema; compatible producers request write grants and values retain producer
+provenance. Preserves canonical queries while allowing competing implementations.
 
 ## Recommendation
 
-Use the small envelope plus facets only, and choose **Option C** for facet ownership.
-
-A producer manifest requests write access to named facets or an explicitly grantable namespace
-pattern. Core approves the request during installation, validates every emitted value, and stores:
-
-- producer or configuring actor;
-- producer plugin and version where applicable;
-- producing Operation Run where applicable;
-- schema version;
-- observation or mutation time.
-
-Two plugins cannot declare the same schema. Multiple authorised plugins may write values under that
-schema. When concurrent or contradictory values are possible, core preserves observations rather
-than silently overwriting provenance; domain policy selects the preferred/current value.
-
-Breaking schema changes require a new facet version or a declared migration. Removing a schema owner
-does not delete stored values; it makes the schema unavailable for new writes until ownership is
-restored or migrated.
-
-## Open question: audit history for mutable facets (input from #217 / DataHub comparison)
-
-DataHub versions *every* aspect update immutably (v0 latest + a positive-number audit trail). Our facet
-values carry producer/version/time provenance but keep no value **history**: a new value for a mutable
-*intent* facet (e.g. `core.processing.mode`) overwrites the prior value. For observation facets this is
-fine (they are effectively write-once). For mutable intent facets, an audit trail ("was `auto`, set to
-`manual` by user X at T") may be worth keeping. This is **not** required before cutover and is out of
-scope for M1 (whose facets are write-once observations); flagged here so the Decision can state whether
-mutable-facet history is in or out, and if in, whether it reuses the immutable-version pattern.
+Small envelope plus facets only, and **Option C** for ownership.
 
 ## Decision
 
 Accepted 2026-08-18 (M0 of RFC #213). Adopt the **small core-owned envelope plus facets as the single
-extension mechanism**, and **Option C — exclusive schema owner with explicit producer grants** — as
-detailed in the sections above (envelope, facets, selector portability, write authority). Option A
-(producer-owned namespaces) is rejected because it forces every Selector, query, and UI to understand
-provider-specific alternatives; Option B (shared declaration by convention) is rejected because it
-cannot establish a canonical definition under schema evolution.
+extension mechanism** and **Option C — exclusive schema owner with explicit producer grants**. Option A
+is rejected because provider-specific alternatives leak into every Selector, query, and UI; Option B is
+rejected because it cannot establish a canonical definition under schema evolution.
 
-**Resolving the #217 audit-history open question:** mutable-facet value **history is out of scope for
-v2.0 / M1.** M1's facets are write-once observations, and a mutable *intent* facet (e.g.
-`core.processing.mode`) overwrites in place, keeping only last-write provenance (actor, plugin, version,
-run, schema version, time) — not a value trail. A full immutable audit trail for mutable intent facets
-is deferred to **post-cutover**; if adopted then, it reuses the immutable-version pattern from
-[ADR-003](ADR-003-storage-layout-and-asset-identity.md) rather than inventing a second mechanism.
+**Envelope.** Every Asset has exactly three core-owned fields: `id` (stable opaque identity, never
+derived from name, path, Source, or external ID), `kind` (one normalized discriminator from a
+domain-pack vocabulary, e.g. `astro.light`), and `name` (mutable, non-unique display name, not the
+path). `namespace` and a descriptor `apiVersion` are deliberately omitted — migrations and
+independently versioned plugin/facet contracts own schema evolution, and no tenancy boundary yet exists
+that Sources and Collections cannot express. Paths and external IDs are mutable/scoped state, not
+identity.
+
+**Facets** are the only extension metadata. A schema declares type/units/nullability/validation, scope
+(Asset / AssetVersion / immutable Collection snapshot), mutability and invalidation, owner and
+producer-grant requirements, index/query hints, and version/migration rules. A facet may carry mutable
+intent or an observed/derived fact, and the schema keeps those distinct:
+
+| Example | Scope | Semantics |
+|---|---|---|
+| `core.processing.mode=auto` | Asset, mutable | User/Source processing intent |
+| `astro.fits.exptime=300 s` | AssetVersion, observed | Extracted from exact bytes |
+| `astro.solve.ra=10.6847°` | AssetVersion, derived | Produced by a solver |
+| `astro.session.integration=12 h` | Collection snapshot, derived | Aggregate over fixed membership |
+
+Raw evidence and a normalized decision stay separate facts (`astro.fits.image_type=LIGHT` observed vs.
+envelope `kind=astro.light`).
+
+**Selector portability.** Selectors reference schema names, not producer plugins. Built-in policies use
+core- or pack-owned schemas; competing producers (Astrometry.net, ASTAP) receive grants to write the
+same canonical `astro.solve.*`. A plugin-owned schema stays selectable for deliberate plugin-specific
+policies, but the UI exposes the dependency and a missing schema makes the policy `blocked`. Values are
+never copied into a second mechanism just to be selectable.
+
+**Write authority.** Core is the only writer of envelope/facet state; plugins propose through a
+capability-limited `AssetContext`. One pack owns each `kind` vocabulary and each facet schema — two
+plugins cannot declare the same schema, but multiple granted producers may write values under it. A
+producer manifest requests access to named facets or a grantable namespace pattern, approved at
+install; core validates every value and stores provenance (actor, plugin + version, producing Operation
+Run, schema version, observation/mutation time). Core preserves observations rather than overwriting
+provenance; domain policy selects the current value. Breaking changes need a new facet version or a
+declared migration; removing a schema owner makes it unavailable for new writes without deleting stored
+values.
+
+**Mutable-facet audit history (#217 / DataHub) is out of scope for v2.0 / M1.** M1's facets are
+write-once observations; a mutable intent facet (`core.processing.mode`) overwrites in place, keeping
+only last-write provenance — not a value trail. A full immutable audit trail is deferred post-cutover
+and, if adopted, reuses [ADR-003](ADR-003-storage-layout-and-asset-identity.md)'s immutable-version
+pattern rather than inventing a second mechanism.

--- a/docs/decisions/ADR-008-facet-schema-and-write-authority.md
+++ b/docs/decisions/ADR-008-facet-schema-and-write-authority.md
@@ -1,6 +1,6 @@
 # 008: Metadata Envelope, Facets, and Write Authority
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-08-01
 **Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). Selectors need a
 portable metadata contract, while domain packs and alternative plugins need interoperable typed
@@ -137,6 +137,49 @@ Breaking schema changes require a new facet version or a declared migration. Rem
 does not delete stored values; it makes the schema unavailable for new writes until ownership is
 restored or migrated.
 
+## Open question: audit history for mutable facets (input from #217 / DataHub comparison)
+
+DataHub versions *every* aspect update immutably (v0 latest + a positive-number audit trail). Our facet
+values carry producer/version/time provenance but keep no value **history**: a new value for a mutable
+*intent* facet (e.g. `core.processing.mode`) overwrites the prior value. For observation facets this is
+fine (they are effectively write-once). For mutable intent facets, an audit trail ("was `auto`, set to
+`manual` by user X at T") may be worth keeping. This is **not** required before cutover and is out of
+scope for M1 (whose facets are write-once observations); flagged here so the Decision can state whether
+mutable-facet history is in or out, and if in, whether it reuses the immutable-version pattern.
+
 ## Decision
 
-[Filled in after review.]
+Accepted 2026-08-18 (M0 of RFC #213). Adopt the **small core-owned envelope plus facets as the single
+extension mechanism**, and **Option C — exclusive schema owner with explicit producer grants** — for
+facet ownership. Option A (producer-owned namespaces) is rejected because it forces every Selector,
+query, and UI to understand provider-specific alternatives; Option B (shared declaration by
+convention) is rejected because it cannot establish a canonical definition under schema evolution.
+
+- **Envelope:** every Asset has `id` (stable opaque identity), `kind` (one normalized discriminator
+  from a domain-pack vocabulary, e.g. `astro.light`), and `name` (mutable, non-unique display name).
+  `namespace` and a descriptor `apiVersion` are deliberately omitted; paths and external IDs are
+  mutable/scoped state and stay out of identity.
+- **Facets** are the only extension metadata. A schema declares type/units/nullability/validation,
+  scope (Asset / AssetVersion / immutable Collection snapshot), mutability and invalidation, owner and
+  producer-grant requirements, index/query hints, and version/migration rules. Raw evidence and a
+  normalized decision stay distinct facts (`astro.fits.image_type=LIGHT` observed vs. envelope
+  `kind=astro.light`).
+- **Selector portability:** selectors reference schema names, not producer plugins. Built-in policies
+  use core- or pack-owned schemas; competing producers (e.g. Astrometry.net and ASTAP) receive grants
+  to write the same canonical `astro.solve.*`. Values are never copied into a second mechanism just to
+  be selectable.
+- **Write authority:** core is the only writer of envelope/facet state; plugins propose through a
+  capability-limited `AssetContext`. One pack owns each `kind` vocabulary and each facet schema; two
+  plugins cannot declare the same schema, but multiple authorized producers may write values under it,
+  retaining producer provenance. Core preserves observations rather than overwriting provenance;
+  domain policy selects the current value. Breaking changes require a new facet version or declared
+  migration; removing a schema owner makes it unavailable for new writes without deleting stored
+  values.
+
+**Resolving the #217 audit-history open question:** mutable-facet value **history is out of scope for
+v2.0 / M1.** M1's facets are write-once observations, and a mutable *intent* facet (e.g.
+`core.processing.mode`) overwrites in place, retaining only last-write provenance (actor, plugin,
+version, run, schema version, time) — not a value trail. A full immutable audit trail for mutable
+intent facets is deferred to **post-cutover**; if adopted then, it reuses the immutable-version
+pattern from [ADR-003](ADR-003-storage-layout-and-asset-identity.md) rather than inventing a second
+mechanism.

--- a/docs/decisions/ADR-008-facet-schema-and-write-authority.md
+++ b/docs/decisions/ADR-008-facet-schema-and-write-authority.md
@@ -38,14 +38,9 @@ provenance. Preserves canonical queries while allowing competing implementations
 
 ## Recommendation
 
-Small envelope plus facets only, and **Option C** for ownership.
-
-## Decision
-
-Accepted 2026-08-18 (M0 of RFC #213). Adopt the **small core-owned envelope plus facets as the single
-extension mechanism** and **Option C — exclusive schema owner with explicit producer grants**. Option A
-is rejected because provider-specific alternatives leak into every Selector, query, and UI; Option B is
-rejected because it cannot establish a canonical definition under schema evolution.
+Small core-owned envelope plus facets as the single extension mechanism, and **Option C** for ownership —
+Option A leaks provider-specific alternatives into every Selector, query, and UI; Option B cannot
+establish a canonical definition under schema evolution. The contract:
 
 **Envelope.** Every Asset has exactly three core-owned fields: `id` (stable opaque identity, never
 derived from name, path, Source, or external ID), `kind` (one normalized discriminator from a
@@ -91,3 +86,8 @@ write-once observations; a mutable intent facet (`core.processing.mode`) overwri
 only last-write provenance — not a value trail. A full immutable audit trail is deferred post-cutover
 and, if adopted, reuses [ADR-003](ADR-003-storage-layout-and-asset-identity.md)'s immutable-version
 pattern rather than inventing a second mechanism.
+
+## Decision
+
+Accepted 2026-08-18 (M0 of RFC #213) — **small core-owned envelope plus facets, Option C**, as
+recommended.

--- a/docs/decisions/ADR-008-facet-schema-and-write-authority.md
+++ b/docs/decisions/ADR-008-facet-schema-and-write-authority.md
@@ -150,36 +150,15 @@ mutable-facet history is in or out, and if in, whether it reuses the immutable-v
 ## Decision
 
 Accepted 2026-08-18 (M0 of RFC #213). Adopt the **small core-owned envelope plus facets as the single
-extension mechanism**, and **Option C — exclusive schema owner with explicit producer grants** — for
-facet ownership. Option A (producer-owned namespaces) is rejected because it forces every Selector,
-query, and UI to understand provider-specific alternatives; Option B (shared declaration by
-convention) is rejected because it cannot establish a canonical definition under schema evolution.
-
-- **Envelope:** every Asset has `id` (stable opaque identity), `kind` (one normalized discriminator
-  from a domain-pack vocabulary, e.g. `astro.light`), and `name` (mutable, non-unique display name).
-  `namespace` and a descriptor `apiVersion` are deliberately omitted; paths and external IDs are
-  mutable/scoped state and stay out of identity.
-- **Facets** are the only extension metadata. A schema declares type/units/nullability/validation,
-  scope (Asset / AssetVersion / immutable Collection snapshot), mutability and invalidation, owner and
-  producer-grant requirements, index/query hints, and version/migration rules. Raw evidence and a
-  normalized decision stay distinct facts (`astro.fits.image_type=LIGHT` observed vs. envelope
-  `kind=astro.light`).
-- **Selector portability:** selectors reference schema names, not producer plugins. Built-in policies
-  use core- or pack-owned schemas; competing producers (e.g. Astrometry.net and ASTAP) receive grants
-  to write the same canonical `astro.solve.*`. Values are never copied into a second mechanism just to
-  be selectable.
-- **Write authority:** core is the only writer of envelope/facet state; plugins propose through a
-  capability-limited `AssetContext`. One pack owns each `kind` vocabulary and each facet schema; two
-  plugins cannot declare the same schema, but multiple authorized producers may write values under it,
-  retaining producer provenance. Core preserves observations rather than overwriting provenance;
-  domain policy selects the current value. Breaking changes require a new facet version or declared
-  migration; removing a schema owner makes it unavailable for new writes without deleting stored
-  values.
+extension mechanism**, and **Option C — exclusive schema owner with explicit producer grants** — as
+detailed in the sections above (envelope, facets, selector portability, write authority). Option A
+(producer-owned namespaces) is rejected because it forces every Selector, query, and UI to understand
+provider-specific alternatives; Option B (shared declaration by convention) is rejected because it
+cannot establish a canonical definition under schema evolution.
 
 **Resolving the #217 audit-history open question:** mutable-facet value **history is out of scope for
 v2.0 / M1.** M1's facets are write-once observations, and a mutable *intent* facet (e.g.
-`core.processing.mode`) overwrites in place, retaining only last-write provenance (actor, plugin,
-version, run, schema version, time) — not a value trail. A full immutable audit trail for mutable
-intent facets is deferred to **post-cutover**; if adopted then, it reuses the immutable-version
-pattern from [ADR-003](ADR-003-storage-layout-and-asset-identity.md) rather than inventing a second
-mechanism.
+`core.processing.mode`) overwrites in place, keeping only last-write provenance (actor, plugin, version,
+run, schema version, time) — not a value trail. A full immutable audit trail for mutable intent facets
+is deferred to **post-cutover**; if adopted then, it reuses the immutable-version pattern from
+[ADR-003](ADR-003-storage-layout-and-asset-identity.md) rather than inventing a second mechanism.

--- a/docs/decisions/ADR-009-backend-language.md
+++ b/docs/decisions/ADR-009-backend-language.md
@@ -1,0 +1,85 @@
+# 009: Backend Language and Runtime
+
+**Status:** Accepted
+**Date:** 2026-08-19
+**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The RFC commits to a
+backend rewrite; this ADR records *why the rewrite is in Rust* rather than leaving the single most
+expensive-to-reverse decision documented only by the RFC title.
+
+## Problem
+
+v2 turns Sidereal from an Immich viewer into the **system of record for files on disk** and runs a
+plugin engine on the ingest hot path. The backend language must serve four things the current
+TypeScript/Hono stack serves weakly:
+
+- **Hot-path throughput** — parsing and hashing hundreds of FITS/XISF frames per session.
+- **Memory safety on a filesystem-mutating system of record** — a rename/move/delete bug here destroys
+  irreplaceable user data.
+- **Concurrency under bursty ingest** without GC-pause tail latency.
+- **A credible plugin-isolation story** — an embeddable script engine and capability limits, with no
+  published dynamic ABI ([ADR-001](ADR-001-plugin-boundary.md)).
+
+Reversing this after M1 means a second rewrite, so it is decided explicitly and up front.
+
+## Options
+
+### Option A: Stay on TypeScript / Node
+
+**Pros:**
+- Keeps the existing backend, its contributors, and one language across the whole stack.
+- Fastest path to a running M1.
+
+**Cons:**
+- CPU-bound FITS parsing and hashing push the real work into native addons or WASM anyway, so the
+  "one language" benefit erodes exactly where performance matters.
+- GC pauses under bursty ingest hurt tail latency.
+- The safest embedding/capability story (in-process script engine, no ambient FS) is weaker than a
+  systems language offers, on the very component that mutates user files.
+
+### Option B: Rust
+
+**Pros:**
+- Native hot-path performance for FITS/XISF parsing and hashing; mature image/numeric crates.
+- Compile-time memory and data-race safety on the component that renames, moves, and deletes originals.
+- Fearless concurrency for parallel ingest with no GC-pause tail.
+- Mature embeddable scripting (Rhai) and a clean capability-limited `AssetContext`, matching ADR-001.
+- Single static binary, supporting the one-command deployment goal.
+
+**Cons:**
+- A real language switch: steeper learning curve, a smaller contributor pool, and the existing TS
+  backend is discarded. This is the RFC's named top risk.
+
+### Option C: Go
+
+**Pros:**
+- Simple, fast to learn, strong concurrency, single binary.
+
+**Cons:**
+- Weaker than Rust for CPU-bound numeric/parsing work, and still GC-paused.
+- A less expressive type system for the Asset/Version/Lineage/facet model, and no
+  Rhai-in-process-caliber embedding story.
+
+## Recommendation
+
+**Option B — Rust.** The decisive factor is that v2's core is a filesystem-mutating, CPU-bound engine
+with an embedded untrusted-plugin surface — precisely where Rust's safety, throughput, and embedding
+maturity pay off and where Node's strengths do not apply. Go is closer than Node but gives up numeric
+performance and type expressiveness for a domain model that leans on both.
+
+## Decision
+
+Accepted 2026-08-19 (M0 of RFC #213). **The v2 backend is written in Rust.** Option A (stay on
+TypeScript) is rejected because the hot path degrades to native addons anyway and GC tail latency and a
+weaker capability story are the wrong trade on a system of record; Option C (Go) is rejected for weaker
+CPU-bound performance and a less expressive type system for the core model.
+
+The language switch is the RFC's top risk, mitigated deliberately:
+
+- **The frontend stays TypeScript/React** and moves as an independent workstream from M1, so existing
+  contributors stay productive through the switch ([ADR-005](ADR-005-frontend-continuity.md)).
+- **Heavy or OS-specific work stays out of the Rust core** — Python ML, Siril/PixInsight/ASTAP run as
+  external providers behind the plugin contract ([ADR-001](ADR-001-plugin-boundary.md)), so choosing
+  Rust for core does not force every integration into Rust.
+
+This ADR fixes the language, not the framework/crate stack (web server, async runtime, image libraries);
+those are ordinary implementation choices settled in code.

--- a/docs/decisions/ADR-009-backend-language.md
+++ b/docs/decisions/ADR-009-backend-language.md
@@ -66,20 +66,14 @@ with an embedded untrusted-plugin surface — precisely where Rust's safety, thr
 maturity pay off and where Node's strengths do not apply. Go is closer than Node but gives up numeric
 performance and type expressiveness for a domain model that leans on both.
 
+The language switch is the RFC's top risk, mitigated deliberately: **the frontend stays TypeScript/React**
+and moves as an independent workstream from M1, so existing contributors stay productive through the
+switch ([ADR-005](ADR-005-frontend-continuity.md)); and **heavy or OS-specific work stays out of the Rust
+core** — Python ML, Siril/PixInsight/ASTAP run as external providers behind the plugin contract
+([ADR-001](ADR-001-plugin-boundary.md)), so choosing Rust for core does not force every integration into
+Rust. This decision fixes the language, not the framework/crate stack (web server, async runtime, image
+libraries); those are ordinary implementation choices settled in code.
+
 ## Decision
 
-Accepted 2026-08-19 (M0 of RFC #213). **The v2 backend is written in Rust.** Option A (stay on
-TypeScript) is rejected because the hot path degrades to native addons anyway and GC tail latency and a
-weaker capability story are the wrong trade on a system of record; Option C (Go) is rejected for weaker
-CPU-bound performance and a less expressive type system for the core model.
-
-The language switch is the RFC's top risk, mitigated deliberately:
-
-- **The frontend stays TypeScript/React** and moves as an independent workstream from M1, so existing
-  contributors stay productive through the switch ([ADR-005](ADR-005-frontend-continuity.md)).
-- **Heavy or OS-specific work stays out of the Rust core** — Python ML, Siril/PixInsight/ASTAP run as
-  external providers behind the plugin contract ([ADR-001](ADR-001-plugin-boundary.md)), so choosing
-  Rust for core does not force every integration into Rust.
-
-This ADR fixes the language, not the framework/crate stack (web server, async runtime, image libraries);
-those are ordinary implementation choices settled in code.
+Accepted 2026-08-19 (M0 of RFC #213) — **Rust**, as recommended.

--- a/docs/decisions/ADR-010-migration-strategy.md
+++ b/docs/decisions/ADR-010-migration-strategy.md
@@ -66,18 +66,11 @@ Run v2 alongside v0.10.x and migrate incrementally, resource by resource.
 
 ## Recommendation
 
-**Option B — clean break with a one-way importer.** The MUST-preserve-compatibility requirements are not
-a neutral constraint; they encode the exact architecture v2 replaces, so honouring them (A) forecloses
-the rewrite, and a strangler (C) pays dual-stack cost indefinitely for a product with one user and one
+**Option B — clean break with a one-way importer**, gated on the non-negotiable cutover feature set in
+[migration.md](../architecture/migration.md). The MUST-preserve-compatibility requirements are not a
+neutral constraint; they encode the exact architecture v2 replaces, so honouring them (A) forecloses the
+rewrite, and a strangler (C) pays dual-stack cost indefinitely for a product with one user and one
 maintainer. A bounded importer that is honest about what it drops is the proportionate path.
-
-## Decision
-
-Accepted 2026-08-19 (M0 of RFC #213). **Clean break with a one-way importer**, gated on the
-non-negotiable cutover feature set in [migration.md](../architecture/migration.md). Option A
-(backward-compatible/in-place) is rejected because preserving the legacy IDs, layout, and API surface
-re-imposes the premises v2 exists to change; Option C (dual-run/strangler) is rejected as an
-indefinite two-model, two-frontend cost unjustified for a single-user product.
 
 - **The analysis package's compatibility MUSTs are explicitly overridden**, not overlooked. It remains
   valuable as a behavioural inventory and as the source of the cutover gate, but v2 is not bound by its
@@ -93,3 +86,7 @@ indefinite two-model, two-frontend cost unjustified for a single-user product.
 
 The full checklist, compatibility-break list, filesystem-safety rules, and rollback detail live in
 [migration.md](../architecture/migration.md); this ADR owns the decision, that doc owns the execution.
+
+## Decision
+
+Accepted 2026-08-19 (M0 of RFC #213) — **clean break with a one-way importer**, as recommended.

--- a/docs/decisions/ADR-010-migration-strategy.md
+++ b/docs/decisions/ADR-010-migration-strategy.md
@@ -1,0 +1,95 @@
+# 010: Migration Strategy — Clean Break with a One-Way Importer
+
+**Status:** Accepted
+**Date:** 2026-08-19
+**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). v2 is a new data
+model; existing v0.10.x users have live data and files. This ADR records *how they reach v2*, and why
+that path knowingly overrides the analysis package's compatibility requirements. The operational detail
+lives in [migration.md](../architecture/migration.md).
+
+## Problem
+
+v0.10.x users hold real data — Immich-mirrored images, plate solves, equipment, acquisitions, saved
+locations — in a SQLite/Postgres database and a storage tree laid out as
+`{STORAGE_PATH}/processed/{id % 1000}/{id}/…`. v2's model is fundamentally different: stable Assets with
+immutable content-addressed Versions, Collections, facets, lineage, on Postgres only
+([ADR-003](ADR-003-storage-layout-and-asset-identity.md), [ADR-004](ADR-004-database-engine-and-schema.md)).
+
+The analysis package (`13-compatibility-requirements.md`) states a replacement **MUST** preserve image
+IDs, that storage layout, every API path and shape, and reconciling-sync semantics. Those requirements
+describe a system where Immich owns the tree and an `Image` is a finished photo — the two premises v2
+exists to change. So the question is unavoidable: honour that compatibility contract, or break it — and
+if we break it, how do users cross over safely?
+
+## Options
+
+### Option A: Backward-compatible / in-place migration
+
+Preserve image IDs, the storage layout, and the API surface; upgrade the existing database in place.
+
+**Pros:**
+- No user-visible break; honours the analysis package's MUST requirements literally.
+
+**Cons:**
+- Re-imposes the old model's premises (Immich-owned tree, `Image` = finished photo) on the new one,
+  defeating the reason for the rewrite.
+- Requires keeping every legacy API path and shape alive on top of a different data model — a large,
+  permanent compatibility surface for a single-maintainer product.
+
+### Option B: Clean break with a one-way importer
+
+v2 is a new model. An importer reads the old database and tree and produces v2 assets best-effort,
+emitting a report of exactly what didn't map. The TypeScript app goes to maintenance, then retires at
+cutover.
+
+**Pros:**
+- The v2 model is unconstrained by v0.10.x shapes.
+- The compatibility surface collapses to one bounded, testable importer instead of a living dual API.
+- Non-goals are explicit and the importer's report makes losses visible rather than silent.
+
+**Cons:**
+- Not seamless; lossy where the models genuinely differ.
+- One-way — after cutover, rollback is restore-from-backup, not a live downgrade.
+
+### Option C: Dual-run / strangler
+
+Run v2 alongside v0.10.x and migrate incrementally, resource by resource.
+
+**Pros:**
+- No single big-bang cutover moment.
+
+**Cons:**
+- Two data models and two frontends live at once for a long time — a very large cost for a single-user,
+  single-maintainer product.
+- The models are too different to share one storage tree safely, which is where the strangler pattern
+  normally gets its leverage.
+
+## Recommendation
+
+**Option B — clean break with a one-way importer.** The MUST-preserve-compatibility requirements are not
+a neutral constraint; they encode the exact architecture v2 replaces, so honouring them (A) forecloses
+the rewrite, and a strangler (C) pays dual-stack cost indefinitely for a product with one user and one
+maintainer. A bounded importer that is honest about what it drops is the proportionate path.
+
+## Decision
+
+Accepted 2026-08-19 (M0 of RFC #213). **Clean break with a one-way importer**, gated on the
+non-negotiable cutover feature set in [migration.md](../architecture/migration.md). Option A
+(backward-compatible/in-place) is rejected because preserving the legacy IDs, layout, and API surface
+re-imposes the premises v2 exists to change; Option C (dual-run/strangler) is rejected as an
+indefinite two-model, two-frontend cost unjustified for a single-user product.
+
+- **The analysis package's compatibility MUSTs are explicitly overridden**, not overlooked. It remains
+  valuable as a behavioural inventory and as the source of the cutover gate, but v2 is not bound by its
+  ID/layout/API-shape preservation requirements.
+- **Both SQLite and Postgres v0.10.x installs** reach v2 through the importer, not in-place dialect
+  migration ([ADR-004](ADR-004-database-engine-and-schema.md)).
+- **The importer is read-only against the source tree**, supports dry-run and resumable execution,
+  records legacy-ID mappings, verifies checksums, and reconciles counts. Its hard invariant: every
+  irreplaceable original is either imported and verified or named in the failure report — an unaccounted
+  original blocks cutover.
+- **Rollback** is disposable-root discard before M6 and restore-from-verified-backup after; the importer
+  stays one-way by design.
+
+The full checklist, compatibility-break list, filesystem-safety rules, and rollback detail live in
+[migration.md](../architecture/migration.md); this ADR owns the decision, that doc owns the execution.

--- a/docs/decisions/ADR-011-storage-tree-layout.md
+++ b/docs/decisions/ADR-011-storage-tree-layout.md
@@ -1,0 +1,62 @@
+# 011: Storage Tree Layout and Cross-Filesystem Moves
+
+**Status:** Proposed
+**Date:** 2026-08-19
+**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). Split out of
+[ADR-003](ADR-003-storage-layout-and-asset-identity.md), which settled Asset/AssetVersion **identity**
+but explicitly left the **on-disk layout** and **move semantics** open. Those govern interruption
+recovery and data safety, so they get their own decision rather than lingering inside an accepted ADR.
+
+**This ADR gates M1.** Per the [STOP-on-open-ADR rule](../../AGENTS.md#open-adrs-block-design--stop), no
+M1 storage design may assume an answer here while this ADR is Proposed — it must be worked with the
+operator and Accepted first.
+
+## Problem
+
+ADR-003 established that identity does not prescribe layout: an `Asset` is a stable surrogate, each
+`AssetVersion` is an immutable content-addressed byte state, and Sidereal is the system of record that
+renames, moves, and organises files. Two questions remain open and must be answered before code touches
+a real tree:
+
+1. **The tree shape.** How are user-visible originals, derived renditions, and superseded versions laid
+   out on disk — one user-meaningful tree, a split between a browsable tree and a protected internal
+   subtree, or something else? How does the layout address a version by hash without exposing opaque IDs
+   as paths?
+2. **Cross-filesystem move behavior.** How is a user-visible move performed and made crash-safe when the
+   source and destination are on different filesystems (where an atomic `rename(2)` is unavailable)?
+
+## Invariants (inherited from ADR-003, binding on any option)
+
+Whatever layout and move strategy are chosen must satisfy:
+
+- database and filesystem updates are recoverable after an interruption;
+- a user-visible move never rewrites content (bytes are preserved; only the path changes);
+- internal historical versions are never presented as duplicate current assets;
+- path traversal and symlink escape are rejected;
+- every stored file can be reconciled to an `AssetVersion` and its hash.
+
+## Options
+
+*(Sketched to frame the decision; to be developed with the operator when M1 storage design opens.)*
+
+### Option A: Single user-meaningful tree
+
+Originals and current renditions live in one tree organised by target/session/date; superseded versions
+are marked in the database but not surfaced as separate current files.
+
+### Option B: Split browsable + protected internal subtree
+
+User-visible originals live in a browsable tree; derived renditions and superseded versions live in a
+separate internal subtree the UI never presents as current assets.
+
+Cross-filesystem moves, under either option, are likely **copy → verify hash → atomically swap the
+reference → reclaim the source**, rather than a non-atomic `rename` across devices — but the exact
+protocol and its crash-recovery steps are part of what this ADR must decide.
+
+## Recommendation
+
+*(To be filled in with the operator during M1 design.)*
+
+## Decision
+
+*[Open — must be worked and Accepted before M1 storage design begins, per the STOP-on-open-ADR rule.]*


### PR DESCRIPTION
Ratifies five of the six remaining M0 ADRs from [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). Each Decision section is written and status flipped to **Accepted**. **ADR-005 (frontend) is intentionally left Proposed** — gated on the contributor conversation and a green v0.10.x E2E baseline, per the ADR's own conditions.

## Accepted

| ADR | Decision |
|---|---|
| **001** Plugin boundary | Capability-oriented hybrid, three profiles behind one semantic contract; Rhai initial script engine (M0 spike, Rune/Lua fallback); WASM deferred. |
| **003** Storage/identity | Option C (stable Asset + immutable AssetVersion). Folds in the #217/DataHub inputs: `current_version_id` pointer with computed `isLatest`, `version_seq`/label navigation, optimistic-concurrency advance. On-disk tree shape left to settle before M1. |
| **004** Database | **PostgreSQL-only** — a deliberate reversal of both the RFC's and the ADR's own SQLite-default leaning. Facets in JSONB + GIN, `sqlx`, forward-only migrations; zero-config install preserved via all-in-one image / compose bundle. |
| **007** Security | Option B (built-in single-user auth, CSRF, deny-by-default CORS, explicit plugin grants); RBAC deferred. M0 exit criteria binding. |
| **008** Facets | Small envelope + facets, Option C exclusive schema ownership; mutable-facet audit history deferred post-cutover (resolves the #217 open question). |

## Held

- **ADR-005** Frontend continuity — remains Proposed (leaning Option C), gated as above.

## Notes for review

- **ADR-004 is the consequential call.** PostgreSQL-only overrides the deployment desideratum the RFC leaned on; the trade-off is accepted and neutralized at the packaging layer (all-in-one image / compose), not the schema layer. The Decision also settles the ADR's coupled "also decide here" items — `sqlx`, JSONB/GIN facet storage, forward-only migrations.
- `docs/architecture/README.md` updated so the "Open seams" table and storage-engine requirements no longer contradict the accepted decisions.
- Already-accepted ADR-002 and ADR-006 are unchanged.

Relates to #213 (M0). Does not close the RFC, which stays open through cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)