### PR TITLE
docs: accept ADR-005, draft ADR-011, and make ADRs self-contained

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,10 @@ alternatives. It is not a changelog. Three tiers keep decisions out of prose wit
 - **Scope / premise** — the RFC or issue, not here.
 
 New ADRs follow `docs/decisions/ADR-000-template.md`, numbered `ADR-NNN-slug.md`. Keep them concise and
-their options concrete.
+their options concrete. **Each ADR stands alone:** options → recommendation → decision, with at most
+**one** link to another ADR (in Context, with number + title) and **no** references to issues,
+milestones, or the RFC — express sequencing as a condition, not a milestone. The Decision ratifies the
+Recommendation in a line when they agree, and explains only a divergence.
 
 ### Lifecycle
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ alternatives. It is not a changelog. Three tiers keep decisions out of prose wit
 their options concrete. 
 
 **Each ADR stands alone:** options → recommendation → decision, with at most **one** link to another ADR 
-(in Context, with number + title). They DO NOT reference ephemerial  materials (issues, milestones, or RFC).
+(in Context, with number + title). They DO NOT reference ephemeral materials (issues, milestones, or RFC).
 
 ### Lifecycle
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,11 +150,11 @@ alternatives. It is not a changelog. Three tiers keep decisions out of prose wit
   *why* later emerges.
 - **Scope / premise** — the RFC or issue, not here.
 
-New ADRs follow `docs/decisions/ADR-000-template.md`, numbered `ADR-NNN-slug.md`. Keep them concise and
-their options concrete. **Each ADR stands alone:** options → recommendation → decision, with at most
-**one** link to another ADR (in Context, with number + title) and **no** references to issues,
-milestones, or the RFC — express sequencing as a condition, not a milestone. The Decision ratifies the
-Recommendation in a line when they agree, and explains only a divergence.
+**New ADRs follow** `docs/decisions/ADR-000-template.md`, numbered `ADR-NNN-slug.md`. Keep them concise and
+their options concrete. 
+
+**Each ADR stands alone:** options → recommendation → decision, with at most **one** link to another ADR 
+(in Context, with number + title). They DO NOT reference ephemerial  materials (issues, milestones, or RFC).
 
 ### Lifecycle
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,6 +1,6 @@
 # Sidereal Architecture
 
-**Architecture reference:** current · **Open architecture decisions:** [ADR-011](../decisions/ADR-011-storage-tree-layout.md) (storage tree) · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) · **Last updated:** 2026-08-20
+**Architecture reference:** current · **Open architecture decisions:** [ADR-011](../decisions/ADR-011-storage-tree-layout.md) (storage tree), [ADR-012](../decisions/ADR-012-embedded-scripting-engine.md) (scripting engine) · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) · **Last updated:** 2026-08-20
 
 > **How to use this map.** This file owns the **architectural map** — the north star and a glossary of
 > the load-bearing concepts — and points to, without restating, the documents that own each thing:
@@ -145,13 +145,14 @@ facet query rather than bespoke schema. → [ADR-008](../decisions/ADR-008-facet
 ## Architecture decisions
 
 Each decision has an ADR in [`docs/decisions/`](../decisions/) with the full context, options, and
-rationale. One remains **Proposed** — ADR-011 (storage tree, which gates M1); the rest are accepted.
+rationale. Two remain **Proposed** — ADR-011 (storage tree, which gates M1) and ADR-012 (scripting
+engine, pending a spike); the rest are accepted.
 
 | ADR | Decision | Status |
 |---|---|---|
 | [001](../decisions/ADR-001-plugin-boundary.md) | Plugin contract & execution profiles | Accepted |
 | [002](../decisions/ADR-002-core-domain-pack-split.md) | Core / domain-pack seam | Accepted |
-| [003](../decisions/ADR-003-storage-layout-and-asset-identity.md) | Storage layout & asset identity | Accepted |
+| [003](../decisions/ADR-003-storage-layout-and-asset-identity.md) | Asset identity & content revisions | Accepted |
 | [004](../decisions/ADR-004-database-engine-and-schema.md) | Database engine & schema strategy | Accepted (PostgreSQL-only) |
 | [005](../decisions/ADR-005-frontend-continuity.md) | Frontend continuity | Accepted (Option C — new shell, port components) |
 | [006](../decisions/ADR-006-rule-engine-deferral.md) | Declarative processing & policy deferral | Accepted |
@@ -160,6 +161,7 @@ rationale. One remains **Proposed** — ADR-011 (storage tree, which gates M1); 
 | [009](../decisions/ADR-009-backend-language.md) | Backend language & runtime | Accepted (Rust) |
 | [010](../decisions/ADR-010-migration-strategy.md) | Migration strategy | Accepted (clean break + one-way importer) |
 | [011](../decisions/ADR-011-storage-tree-layout.md) | Storage tree layout & cross-filesystem moves | **Proposed** — split from ADR-003; gates M1 |
+| [012](../decisions/ADR-012-embedded-scripting-engine.md) | Embedded scripting engine | **Proposed** — Rhai, pending spike |
 
 **ADR-001 and ADR-007 are coupled** — the execution profile says how code runs; grants and
 `AssetContext` say what it may do. Neither is complete without the other.
@@ -178,6 +180,24 @@ a contested *why*, promote it to an ADR and it becomes a row above.
   we don't repeat).
 - **A plugin may implement multiple capabilities** — Immich is both a Source and a Sink; the
   registration mechanism is one.
+- **Session is a core concept with pack vocabulary** — core knows the generic time-bounded,
+  subject-bearing Collection; the astro pack supplies the "session" term and its facet values.
+  (Follows from the seam in [ADR-002](../decisions/ADR-002-core-domain-pack-split.md); promoting more
+  of the concept to core later is additive.)
+- **Equipment is pack-owned** — every equipment field is astro-shaped, so it lives in the astro pack
+  and core stays domain-free. Promoting a concept to core later is cheap and additive; pushing astro
+  fields into core now would be a migration to undo.
+- **Packs contribute API and facet schemas, not frontend** — a pack ships backend behaviour and facet
+  schemas carrying render metadata (type, unit, label, filterability, render hint); the single React app
+  renders facets generically, with first-party astro views (sky map, visibility) in that app. No dynamic
+  frontend plugin ABI in v2.0; adding one later is additive.
+- **Current-version selection is a pointer, `isLatest` is computed** — an Asset's current byte state is
+  a separate `Asset.current_version_id` pointer, not a moving `v0` sentinel; per-version "latest" is
+  derived from it, never a stored boolean. Advancing the pointer uses optimistic concurrency — a
+  compare-and-swap guarded by an `Asset.revision` counter. A dense per-Asset `version_seq` ordinal plus
+  optional curated `label`/`aliases`/`note` are navigation metadata, not identity. (Implements Option C
+  of [ADR-003](../decisions/ADR-003-storage-layout-and-asset-identity.md); confirmed against DataHub's
+  aspect-versioning model.)
 
 ## Build shape
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,6 +1,6 @@
 # Sidereal Architecture
 
-**Architecture reference:** current · **Open architecture decisions:** [ADR-005](../decisions/ADR-005-frontend-continuity.md) (frontend), [ADR-011](../decisions/ADR-011-storage-tree-layout.md) (storage tree) · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) · **Last updated:** 2026-08-19
+**Architecture reference:** current · **Open architecture decisions:** [ADR-011](../decisions/ADR-011-storage-tree-layout.md) (storage tree) · **Tracks:** [RFC #213](https://github.com/sidereal-io/sidereal/issues/213) · **Last updated:** 2026-08-20
 
 > **How to use this map.** This file owns the **architectural map** — the north star and a glossary of
 > the load-bearing concepts — and points to, without restating, the documents that own each thing:
@@ -145,8 +145,7 @@ facet query rather than bespoke schema. → [ADR-008](../decisions/ADR-008-facet
 ## Architecture decisions
 
 Each decision has an ADR in [`docs/decisions/`](../decisions/) with the full context, options, and
-rationale. Two remain **Proposed** — ADR-005 (frontend) and ADR-011 (storage tree, which gates M1); the
-rest are accepted.
+rationale. One remains **Proposed** — ADR-011 (storage tree, which gates M1); the rest are accepted.
 
 | ADR | Decision | Status |
 |---|---|---|
@@ -154,7 +153,7 @@ rest are accepted.
 | [002](../decisions/ADR-002-core-domain-pack-split.md) | Core / domain-pack seam | Accepted |
 | [003](../decisions/ADR-003-storage-layout-and-asset-identity.md) | Storage layout & asset identity | Accepted |
 | [004](../decisions/ADR-004-database-engine-and-schema.md) | Database engine & schema strategy | Accepted (PostgreSQL-only) |
-| [005](../decisions/ADR-005-frontend-continuity.md) | Frontend continuity | **Proposed** — gated on the contributor conversation + a green v0.10.x E2E baseline |
+| [005](../decisions/ADR-005-frontend-continuity.md) | Frontend continuity | Accepted (Option C — new shell, port components) |
 | [006](../decisions/ADR-006-rule-engine-deferral.md) | Declarative processing & policy deferral | Accepted |
 | [007](../decisions/ADR-007-security-and-plugin-trust.md) | Security & plugin trust | Accepted |
 | [008](../decisions/ADR-008-facet-schema-and-write-authority.md) | Metadata envelope, facets & write authority | Accepted |
@@ -172,8 +171,8 @@ Anything with real trade-offs is an ADR (table above); product scope lives in RF
 a contested *why*, promote it to an ADR and it becomes a row above.
 
 - **The frontend stays TypeScript/React** through the backend's move to Rust — the deliberate continuity
-  that keeps current contributors productive. (Evolve-vs-start-fresh is
-  [ADR-005](../decisions/ADR-005-frontend-continuity.md)'s separate, still-open call.)
+  that keeps current contributors productive. (How M5 starts from it — a new shell with ported
+  components — is settled in [ADR-005](../decisions/ADR-005-frontend-continuity.md).)
 - **Derived values are always computed, never stored** — integration totals and the like are recomputed
   from member assets and their facets, never denormalised onto a row that can drift (a v0.10.x mistake
   we don't repeat).

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -6,7 +6,8 @@ Everything Sidereal v2 *does* to a user's files uses the plugin contract. This d
 a plugin receives, what it may request, what it returns, and how it proves conformance.
 
 The contract is **transport-independent**. [ADR-001](../decisions/ADR-001-plugin-boundary.md) defines
-three execution profiles — built-in Rust, embedded script (Rhai, pending the M0 spike), and an external
+three execution profiles — built-in Rust, embedded script (engine per
+[ADR-012](../decisions/ADR-012-embedded-scripting-engine.md), pending the M0 spike), and an external
 provider — over the same semantics. Built-ins do not receive an unconstrained private API merely because they are compiled in.
 
 ## Contents

--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -23,7 +23,7 @@ graph LR
 
 | Milestone | Exit criterion |
 |---|---|
-| **M0** Contracts & scaffolding | All M0 ADRs accepted (ADR-011 the last open one, gating M1), including security and plugin grants; Rhai/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
+| **M0** Contracts & scaffolding | All M0 ADRs accepted (ADR-011 gating M1, ADR-012 pending its spike), including security and plugin grants; the ADR-012 engine/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
 | **M1** Core spine & first plugins | Drop a file in a watched folder → it appears in the UI with extracted metadata, entirely through plugin contracts |
 | **M2** Operator engine & API v0.1 | Operator API, `AssetContext`, selector contract, side-effect protocol published; four built-ins consume it, ≥2 through the embedded script profile; durable goals, reconciliation, and recovery-after-missed-events proven |
 | **M3** Astro domain pack | Source facets + built-in policy converge a full session — lights + darks + flats → grouped, masters matched, lineage recorded |

--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -23,7 +23,7 @@ graph LR
 
 | Milestone | Exit criterion |
 |---|---|
-| **M0** Contracts & scaffolding | All M0 ADRs accepted (ADR-005 the last open one), including security and plugin grants; Rhai/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
+| **M0** Contracts & scaffolding | All M0 ADRs accepted (ADR-011 the last open one, gating M1), including security and plugin grants; Rhai/`AssetContext` spike complete; CI green; a contributor goes zero-to-running in one command |
 | **M1** Core spine & first plugins | Drop a file in a watched folder → it appears in the UI with extracted metadata, entirely through plugin contracts |
 | **M2** Operator engine & API v0.1 | Operator API, `AssetContext`, selector contract, side-effect protocol published; four built-ins consume it, ≥2 through the embedded script profile; durable goals, reconciliation, and recovery-after-missed-events proven |
 | **M3** Astro domain pack | Source facets + built-in policy converge a full session — lights + darks + flats → grouped, masters matched, lineage recorded |

--- a/docs/decisions/ADR-000-template.md
+++ b/docs/decisions/ADR-000-template.md
@@ -2,7 +2,13 @@
 
 **Status:** Proposed | Accepted | Superseded by NNN
 **Date:** YYYY-MM-DD
-**Context:** What work or context prompted this decision?
+**Context:** What situation makes this decision necessary? If this ADR genuinely builds on another, name
+that one ADR here — `[ADR-0NN — Short title](ADR-0NN-slug.md)` — and only here.
+
+> **An ADR stands on its own** — options, a recommendation, a decision, nothing more. At most **one**
+> link to another ADR, in Context above; everywhere else, state facts inline. **Never** reference issues,
+> milestones, or the RFC — they are tracking and plan artifacts, not standing context. Express sequencing
+> as a condition ("once the organize/move operators exist"), never as a milestone number.
 
 ## Problem
 

--- a/docs/decisions/ADR-000-template.md
+++ b/docs/decisions/ADR-000-template.md
@@ -1,7 +1,7 @@
 # NNN: Short Decision Title
 
-**Status:** Proposed | Accepted | Superseded by NNN
-**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Superseded by NNN · **Date:** YYYY-MM-DD
+
 **Context:** What situation makes this decision necessary? If this ADR genuinely builds on another, name
 that one ADR here — `[ADR-0NN — Short title](ADR-0NN-slug.md)` — and only here.
 

--- a/docs/decisions/ADR-001-plugin-boundary.md
+++ b/docs/decisions/ADR-001-plugin-boundary.md
@@ -2,9 +2,10 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The plugin contract in
-[plugins.md](../architecture/plugins.md) defines the common semantics; this ADR chooses how different
-classes of plugin execute and are installed.
+**Context:** This ADR chooses how different classes of plugin execute and are installed, behind one
+common semantic contract. It is coupled with [ADR-007 — Security & plugin
+trust](ADR-007-security-and-plugin-trust.md): execution profile says how code runs; that decision says
+what it may do.
 
 ## Problem
 
@@ -38,7 +39,7 @@ A **capability-oriented hybrid** with three execution profiles behind one semant
 | **Embedded script** | Default public extension surface for lightweight Operators, Sources, Sinks | Manifest + Rhai source in a plugin bundle |
 | **External provider** | Python ML, Siril/PixInsight/ASTAP, hardware- or OS-specific tools | Separately installed service; manifest configures its endpoint |
 
-The initial scripting engine is **Rhai**, subject to an M0 spike proving cancellation, operation/memory
+The initial scripting engine is **Rhai**, subject to a spike proving cancellation, operation/memory
 limits, async host calls, manifest loading, and the `AssetContext` API; Rune and Lua remain fallbacks.
 WASM is deferred until a concrete plugin needs portable compiled components the script profile cannot
 meet. This is **not** the rejected "hybrid" where built-ins get an unconstrained private API — all
@@ -47,7 +48,7 @@ the transport adapter differs.
 
 The interface is batch-oriented (an Operator receives an asset set, not one call per asset) and large
 file bytes never cross a JSON/gRPC boundary — co-located providers get read-only handles or disposable
-paths, remote providers use explicit streaming. An M0 benchmark on a 500+ frame session sizes batching
+paths, remote providers use explicit streaming. A benchmark on a 500+ frame session sizes batching
 without reopening the semantic contract.
 
 **`AssetContext` is the only route from plugin code to core** — approved metadata/facets, mediated byte
@@ -55,19 +56,18 @@ access (read-only stream, descriptor, mount, or disposable copy), emitting new a
 facets, core-managed rename/move/tag/publish intents, allowlisted HTTP, manifest-declared run-scoped
 secrets, and logs/progress/cancellation. No profile gets a writable path into the store; core imports
 and hashes produced files into `AssetVersion` records. Host capabilities each carry their own timeout
-and cancellation. The full enumeration lives in [plugins.md](../architecture/plugins.md).
+and cancellation. The full capability enumeration is part of the plugin contract.
 
 Execution profile is not a trust level: built-in Rust is trusted first-party code, while script bundles
-and external providers get explicit capabilities at install, with authentication, grants, and secret
-delivery defined by [ADR-007](ADR-007-security-and-plugin-trust.md). There is **no published Rust dynamic
-ABI**. v0.1 does not orchestrate plugin containers, provision Python environments, or manage
+and external providers get explicit capabilities at install; authentication, grants, and secret delivery
+are settled separately (the coupled trust decision). There is **no published Rust dynamic ABI**. v0.1 does not orchestrate plugin containers, provision Python environments, or manage
 external-provider upgrades — an external provider is a user-managed dependency. The embedded-script
 profile is declared stable only after **≥2 built-ins also ship through it** (initial candidates:
 tag/rename and API-based plate solving). A compiled built-in can still panic with core, so only trusted
 first-party code belongs in that profile; WASM and container orchestration remain reversible later
-additions, not M0 prerequisites.
+additions, not up-front prerequisites.
 
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213) — the **capability-oriented hybrid**, as recommended. The embedded
-scripting engine (**Rhai**) is contingent on the M0 spike, with Rune/Lua as fallbacks.
+Accepted 2026-08-18 — the **capability-oriented hybrid**, as recommended. The embedded scripting engine
+(**Rhai**) is contingent on the spike, with Rune/Lua as fallbacks.

--- a/docs/decisions/ADR-001-plugin-boundary.md
+++ b/docs/decisions/ADR-001-plugin-boundary.md
@@ -1,7 +1,7 @@
 # 001: Plugin Contract and Execution Profiles
 
-**Status:** Accepted
-**Date:** 2026-07-29
+**Status:** Accepted · **Date:** 2026-07-29
+
 **Context:** This ADR chooses how different classes of plugin execute and are installed, behind one
 common semantic contract. It is coupled with [ADR-007 — Security & plugin
 trust](ADR-007-security-and-plugin-trust.md): execution profile says how code runs; that decision says
@@ -9,13 +9,21 @@ what it may do.
 
 ## Problem
 
-Every v2 pipeline action uses the plugin contract, including built-ins. The original proposal treated
-"plugin contract" and "process boundary" as one decision, but the workloads do not share one useful
-boundary: FITS/XISF parsing and other hot paths need low overhead; user-authored rename/tag/metadata
-work should be easy to install and tightly capability-limited; Python ML, Siril, PixInsight, and ASTAP
-may need large native runtimes, another OS, or process isolation. Forcing all three through one runtime
-either makes the default install complex or over-grants third-party code. The contract and its
-execution transport therefore need separate decisions.
+Every v2 pipeline action is a plugin, built-ins included, so a single semantic contract
+(Source/Operator/Sink) must cover all of them. But the workloads behind that contract have
+irreconcilable execution needs, and no single runtime serves all three:
+
+- **Hot paths** — FITS/XISF parsing, storage adapters, core astro operations — need low overhead and
+  run as trusted first-party code.
+- **User-authored extensions** — rename/tag/metadata work — must be easy to install (no extra container
+  or language runtime) and tightly capability-limited, because they are third-party.
+- **Heavyweight external tools** — Python ML, Siril, PixInsight, ASTAP — may need large native runtimes,
+  another OS, or process isolation so a failure cannot take down core.
+
+Forcing all three through one runtime either makes the default install complex or over-grants
+third-party code. So the question is: **how many execution transports, and which, sit behind the one
+semantic contract** — while keeping that contract identical across every profile so a result means the
+same thing however it ran.
 
 ## Decision drivers
 
@@ -29,45 +37,85 @@ execution transport therefore need separate decisions.
 - **No published Rust dynamic ABI** — compiler ABI instability rules out dylibs as the third-party
   contract.
 
+## Options
+
+### Option A: Single runtime for everything
+One transport behind the contract — every plugin, built-in or third-party, runs the same way.
+**Pros:**
+- Simplest mental model; one conformance path.
+
+**Cons:**
+- No single choice fits all three workloads: an in-process runtime over-grants third-party code and
+  can't host another OS/large native tool; an out-of-process runtime taxes every hot path with IPC.
+- Forces either a complex default install or an unsafe capability surface.
+
+### Option B: Published Rust dynamic ABI (dylibs) for third-party plugins
+Third parties compile against a stable Rust ABI and ship dynamic libraries loaded into core.
+**Pros:**
+- Native performance for third-party code; one language.
+
+**Cons:**
+- Rust has no stable compiler ABI — dylibs break across toolchain versions, so this is not a durable
+  third-party contract.
+- In-process loading gives third-party code the same authority as core; no isolation.
+
+### Option C: WASM-first extension surface
+Third-party plugins ship as portable WASM components sandboxed by the host.
+**Pros:**
+- Strong sandbox, portable compiled artifacts, language-agnostic.
+
+**Cons:**
+- Heavier up-front investment (host bindings, the component toolchain) before any plugin needs portable
+  compiled components.
+- Doesn't address the heavyweight-external-tool case (Python/Siril/PixInsight still need their own
+  runtimes and isolation).
+
+### Option D: Capability-oriented hybrid — three profiles, one contract *(recommended)*
+Three execution profiles — **built-in Rust**, **embedded script**, **external provider** — behind one
+semantic contract and conformance suite; each workload uses the profile that fits, and only the
+transport adapter differs.
+**Pros:**
+- Each workload gets the right transport: low-overhead built-ins, an easy-to-install capability-limited
+  script surface, and isolated external providers.
+- Simple default install (no container/runtime for a normal plugin); isolation only where it's needed.
+- WASM and container orchestration stay reversible later additions, not prerequisites.
+
+**Cons:**
+- More than one transport adapter to build and keep conformant against the shared contract.
+- Requires discipline that built-ins get **no** privileged private API — otherwise it degrades into a
+  two-tier system where built-ins and plugins diverge.
+
 ## Recommendation
 
-A **capability-oriented hybrid** with three execution profiles behind one semantic contract:
+**Option D — the capability-oriented hybrid.** It is the only option that serves all three workloads
+without over-granting or over-building. Three profiles sit behind one contract; only the transport
+adapter differs, and every profile runs the identical conformance suite:
 
 | Profile | Intended use | Packaging |
 |---|---|---|
 | **Built-in Rust** | Trusted, performance-sensitive first-party behavior: FITS/XISF readers, storage adapters, core astro operations | Compiled into the binary as crates |
-| **Embedded script** | Default public extension surface for lightweight Operators, Sources, Sinks | Manifest + Rhai source in a plugin bundle |
+| **Embedded script** | Default public extension surface for lightweight Operators, Sources, Sinks | Manifest + script source in a plugin bundle |
 | **External provider** | Python ML, Siril/PixInsight/ASTAP, hardware- or OS-specific tools | Separately installed service; manifest configures its endpoint |
 
-The initial scripting engine is **Rhai**, subject to a spike proving cancellation, operation/memory
-limits, async host calls, manifest loading, and the `AssetContext` API; Rune and Lua remain fallbacks.
-WASM is deferred until a concrete plugin needs portable compiled components the script profile cannot
-meet. This is **not** the rejected "hybrid" where built-ins get an unconstrained private API — all
-profiles implement identical request/result semantics and capability-specific conformance tests; only
-the transport adapter differs.
+Two invariants are non-negotiable, or the hybrid degrades into a two-tier system:
 
-The interface is batch-oriented (an Operator receives an asset set, not one call per asset) and large
-file bytes never cross a JSON/gRPC boundary — co-located providers get read-only handles or disposable
-paths, remote providers use explicit streaming. A benchmark on a 500+ frame session sizes batching
-without reopening the semantic contract.
+- **No privileged built-in API.** Built-ins get no back door — same request/result semantics and
+  conformance tests as any plugin.
+- **`AssetContext` is the only route from plugin code to core.** No profile gets a writable path into the
+  store or ambient asset/secret/process/network access; core imports and hashes produced files into
+  `AssetVersion` records. The full capability enumeration belongs to the plugin contract.
 
-**`AssetContext` is the only route from plugin code to core** — approved metadata/facets, mediated byte
-access (read-only stream, descriptor, mount, or disposable copy), emitting new assets and proposed
-facets, core-managed rename/move/tag/publish intents, allowlisted HTTP, manifest-declared run-scoped
-secrets, and logs/progress/cancellation. No profile gets a writable path into the store; core imports
-and hashes produced files into `AssetVersion` records. Host capabilities each carry their own timeout
-and cancellation. The full capability enumeration is part of the plugin contract.
-
-Execution profile is not a trust level: built-in Rust is trusted first-party code, while script bundles
-and external providers get explicit capabilities at install; authentication, grants, and secret delivery
-are settled separately (the coupled trust decision). There is **no published Rust dynamic ABI**. v0.1 does not orchestrate plugin containers, provision Python environments, or manage
-external-provider upgrades — an external provider is a user-managed dependency. The embedded-script
-profile is declared stable only after **≥2 built-ins also ship through it** (initial candidates:
-tag/rename and API-based plate solving). A compiled built-in can still panic with core, so only trusted
-first-party code belongs in that profile; WASM and container orchestration remain reversible later
-additions, not up-front prerequisites.
+The engine for the embedded-script profile is chosen downstream, not here. A portable compiled-component
+surface (WASM, Option C) is deferred until a plugin needs one the script profile cannot serve, as is
+container orchestration and external-provider lifecycle management — an external provider is a
+user-managed dependency. Both remain additive later, not prerequisites. The interface is batch-oriented
+(an Operator receives an asset set) and large file bytes never cross the request/response boundary;
+exact batch sizing is tuning, not part of this decision. The embedded-script profile is declared stable
+only after **≥2 built-ins also ship through it**, forcing it to prove itself on first-party work before
+third parties depend on it.
 
 ## Decision
 
-Accepted 2026-08-18 — the **capability-oriented hybrid**, as recommended. The embedded scripting engine
-(**Rhai**) is contingent on the spike, with Rune/Lua as fallbacks.
+Accepted 2026-08-18 — the **capability-oriented hybrid**, as recommended. The choice of embedded
+scripting engine is left to a downstream decision, to be proven against the profile's requirements before
+it is committed.

--- a/docs/decisions/ADR-002-core-domain-pack-split.md
+++ b/docs/decisions/ADR-002-core-domain-pack-split.md
@@ -1,27 +1,22 @@
 # 002: Core / Domain-Pack Seam
 
-**Status:** Accepted
-**Date:** 2026-07-29
-**Context:** The core is domain-agnostic with astrophotography as the first domain pack; this ADR fixes where the seam actually falls and how packs are delivered. It builds on the plugin execution profiles in [ADR-001 — Plugin contract & execution profiles](ADR-001-plugin-boundary.md).
+**Status:** Accepted · **Date:** 2026-07-29
+
+**Context:** Core is domain-agnostic and the astrophotography pack is the first domain pack — that split is settled. This ADR fixes one thing: how the first-party astro pack is *delivered*, which in turn fixes where the seam physically falls. It builds on the plugin execution profiles in [ADR-001 — Plugin contract & execution profiles](ADR-001-plugin-boundary.md).
 
 ## Problem
 
-The principle is settled: `kind` must not be a Rust enum containing `light | dark | flat`, and astro vocabulary belongs to a pack rather than to core. Two questions remain.
+The astro pack has to reach users somehow, and that choice determines how real the core/pack seam is. A pack compiled into the binary proves the seam only by convention; a pack loaded at runtime proves it by construction — but pays a boundary cost on every ingest and needs a much larger contract, because a pack contributes UI and schemas, not just backend behaviour like an Operator plugin.
 
-**1. Where exactly does the seam fall?** A first cut:
+This matters because the astro pack sits on the hot path. Its FITS/XISF readers run for every ingest, and large FITS files make any per-ingest boundary crossing expensive. The execution profiles from ADR-001 separate semantic contracts from transport: a pack can use the built-in Rust profile and cross no dynamic boundary, or a script/external-provider profile and cross one on every asset.
 
-- *Core:* Asset, Collection, Lineage, Operation Run, plugin registry, storage layout, search/index, job queue, web shell.
-- *Astro pack:* FITS/XISF readers, astro kind vocabulary, calibration sets and master matching, sessions, OpenNGC catalog, visibility math, targets and annotations, equipment, acquisitions, plate solving, sky map.
-
-Several of those are genuinely ambiguous. **Equipment** is arguably general (any camera-based hobby has gear) but its spec fields are astro-shaped. **Sessions** are a Collection specialisation — does core know the concept and the pack fill it in, or does the pack define it wholesale? **Visibility math** is pure astronomy but drives generic UI sorting.
-
-**2. Are packs compiled in or loaded at runtime?** The execution profiles separate semantic contracts
-from transport. A pack containing a FITS reader is on the hot path for every ingest and may use the
-built-in Rust profile without receiving a different semantic contract.
+So the question is not *whether* astro vocabulary lives in a pack — it does — but whether that pack is **compiled in, loaded at runtime, or reduced to almost nothing** so the seam is trivially clean. Each answer draws the physical seam in a different place.
 
 ## Options
 
 ### Option A: Astro pack compiled in, other plugins loaded
+
+The astro pack is a first-party crate compiled into the binary, coded against the public pack contract but shipped as part of the single artifact. Third-party Operators and Sources still load at runtime.
 
 **Pros:**
 - No boundary cost on the hot ingest path (FITS parsing, facet extraction).
@@ -34,18 +29,21 @@ built-in Rust profile without receiving a different semantic contract.
 
 ### Option B: Packs are ordinary loadable plugins
 
+The astro pack is a dynamically loaded plugin like any other — installed, not compiled in.
+
 **Pros:**
 - Seam proven by construction — if the astro pack can be loaded, so can a third-party pack.
 - A future general-media pack needs no core change.
 - Users install only what they use.
 
 **Cons:**
-- A dynamically loaded pack using the script or external-provider profile adds boundary cost on every
-  ingest, which may be significant for large FITS files.
+- A dynamically loaded pack using the script or external-provider profile adds boundary cost on every ingest, which may be significant for large FITS files.
 - Packs need to contribute UI, not just backend behaviour — a much larger contract than an Operator plugin.
 - More moving parts in the default install.
 
 ### Option C: Thin core with facets only; everything else a pack
+
+Core shrinks to facet storage and query; every capability, including cross-pack UI concerns, ships as a pack.
 
 **Pros:**
 - Maximally clean seam; core is small and genuinely domain-free.
@@ -56,54 +54,14 @@ built-in Rust profile without receiving a different semantic contract.
 
 ## Recommendation
 
-Working position: **decide the seam now and compile the first-party astro pack into v2.0.** It uses
-the built-in Rust execution profile and implements the same semantic contracts and conformance fixtures.
-User-installed script plugins and external providers can extend its schemas and Operators through
-explicit grants; dynamically replacing the entire domain pack is deferred.
-
-This keeps FITS/XISF parsing and the initial UI contribution in the shipped artifact without making
-astro vocabulary part of core. Whether a later domain pack can be dynamically installed remains
-reversible; putting astro fields into core does not.
-
-Specific calls to make explicit:
-
-- Does core know the *concept* "session" (a Collection with a time span and a subject) with the pack supplying vocabulary, or is session entirely pack-defined?
-- Equipment: core, pack, or core concept with pack-defined spec facets?
-- Can a pack contribute frontend surface, or only API and facets? This gates whether the frontend workstream can proceed independently.
+**Option A.** The seam only has to be *real*, not *dynamic*, to keep astro vocabulary out of core — and A gets that for free while B pays a per-ingest boundary cost exactly where it hurts most (large FITS files) and C ships nothing useful for too long. Coding the pack against the public contract, not `core` internals, makes the boundary genuine; whether a pack can later be *loaded* rather than compiled in stays reversible, because compiled-in → loadable is additive. Putting astro fields into core would not be reversible, so A is the safe direction.
 
 ## Decision
 
-The concrete crate skeleton makes this seam physical, so it is
-decided now rather than deferred. All four calls below are taken in the
-reversible-safe direction — compiled-in → loadable, pack-owned → core, and
-API-only → UI-ABI are each additive later, while the reverse would be a
-migration.
+Accepted 2026-07-29 — **Option A, as recommended.** The astro pack is the `packs/astro` crate, compiled into v2.0. It codes against the public `plugin-abi` contract — the same Source/Operator/Sink traits and registry a third-party pack would use — never against `core` internals, enforced structurally (astro depends on `plugin-abi` only) and by a dependency-direction lint. It uses the built-in Rust execution profile and implements the same semantic contracts and conformance fixtures a third party would. Dynamically replacing the whole domain pack is **deferred, not designed out**: the contract boundary exists today; only the dynamic loader is absent.
 
-**1. Seam = Option A.** The first-party astro pack is compiled into v2.0 as the
-`packs/astro` crate. It codes against the public `plugin-abi` contract — the same
-Source/Operator/Sink traits and registry a third-party pack would use — and never
-against `core` internals; that direction is enforced structurally (astro depends on
-`plugin-abi` only) and by a dependency-direction lint. The pack uses the
-built-in Rust execution profile and implements the same semantic contracts and
-conformance fixtures a third party would. Dynamically replacing the whole domain
-pack is **deferred, not designed out**: the contract boundary exists today; only the
-dynamic loader is absent.
+The seam being physical now settles three boundary questions in the same reversible-safe direction (each additive to reverse, so none needs its own ADR — they are recorded as design facts in [the architecture overview](../architecture/README.md#design-facts)):
 
-**2. Session = core concept, pack vocabulary.** Core knows the generic notion of a
-time-bounded, subject-bearing Collection. The astro pack supplies the "session"
-vocabulary and its facet values. Core does not hardcode astronomy, and the pack does
-not reinvent Collections.
-
-**3. Equipment = pack-owned.** Every equipment field is astro-shaped, so equipment
-lives entirely in the astro pack and core stays domain-free. Promoting a concept to
-core later is cheap and additive; pushing astro fields into core now would be a
-migration to undo.
-
-**4. Frontend = API + descriptive facet schemas only.** Packs contribute backend
-behaviour and facet schemas carrying render metadata (type, unit, label,
-filterability, render hint). The single TypeScript frontend renders facets
-generically; first-party astro views (sky map, visibility) live in the shared React
-app. There is **no dynamic frontend plugin ABI in v2.0**; dynamic UI contribution is
-deferred until after cutover. This keeps the frontend an independently-moving React app
-and is consistent with the caution against a published dynamic ABI. Adding a
-UI-contribution mechanism later is purely additive.
+- **Session** is a core concept with pack vocabulary — core knows the generic time-bounded, subject-bearing Collection; the astro pack supplies the "session" term and its facet values.
+- **Equipment** is pack-owned — every equipment field is astro-shaped, so it lives in the astro pack and core stays domain-free.
+- **Frontend contribution** is API + descriptive facet schemas only — packs contribute backend behaviour and facet schemas carrying render metadata (type, unit, label, filterability, render hint); the single React app renders facets generically, with first-party astro views (sky map, visibility) living in that app. There is no dynamic frontend plugin ABI in v2.0.

--- a/docs/decisions/ADR-002-core-domain-pack-split.md
+++ b/docs/decisions/ADR-002-core-domain-pack-split.md
@@ -2,22 +2,22 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The [architecture](../architecture/README.md#core-and-domain-packs) commits to a domain-agnostic core with astrophotography as the first domain pack. This ADR fixes where the seam actually falls and how packs are delivered.
+**Context:** The core is domain-agnostic with astrophotography as the first domain pack; this ADR fixes where the seam actually falls and how packs are delivered. It builds on the plugin execution profiles in [ADR-001 — Plugin contract & execution profiles](ADR-001-plugin-boundary.md).
 
 ## Problem
 
 The principle is settled: `kind` must not be a Rust enum containing `light | dark | flat`, and astro vocabulary belongs to a pack rather than to core. Two questions remain.
 
-**1. Where exactly does the seam fall?** The RFC's first cut:
+**1. Where exactly does the seam fall?** A first cut:
 
 - *Core:* Asset, Collection, Lineage, Operation Run, plugin registry, storage layout, search/index, job queue, web shell.
 - *Astro pack:* FITS/XISF readers, astro kind vocabulary, calibration sets and master matching, sessions, OpenNGC catalog, visibility math, targets and annotations, equipment, acquisitions, plate solving, sky map.
 
 Several of those are genuinely ambiguous. **Equipment** is arguably general (any camera-based hobby has gear) but its spec fields are astro-shaped. **Sessions** are a Collection specialisation — does core know the concept and the pack fill it in, or does the pack define it wholesale? **Visibility math** is pure astronomy but drives generic UI sorting.
 
-**2. Are packs compiled in or loaded at runtime?** [ADR-001](ADR-001-plugin-boundary.md) separates
-semantic contracts from execution profiles. A pack containing a FITS reader is on the hot path for
-every ingest and may use the built-in Rust profile without receiving a different semantic contract.
+**2. Are packs compiled in or loaded at runtime?** The execution profiles separate semantic contracts
+from transport. A pack containing a FITS reader is on the hot path for every ingest and may use the
+built-in Rust profile without receiving a different semantic contract.
 
 ## Options
 
@@ -51,15 +51,15 @@ every ingest and may use the built-in Rust profile without receiving a different
 - Maximally clean seam; core is small and genuinely domain-free.
 
 **Cons:**
-- Realistically means shipping nothing useful for a long time, and the RFC's milestones assume a working vertical slice at M1.
+- Realistically means shipping nothing useful for a long time, when a working vertical slice is needed early.
 - Risks the core being *too* thin — cross-pack concerns (search UI, collection views) end up duplicated per pack.
 
 ## Recommendation
 
 Working position: **decide the seam now and compile the first-party astro pack into v2.0.** It uses
-the built-in Rust execution profile from ADR-001 and implements the same semantic contracts and
-conformance fixtures. User-installed Rhai plugins and external providers can extend its schemas and
-Operators through explicit grants; dynamically replacing the entire domain pack is deferred.
+the built-in Rust execution profile and implements the same semantic contracts and conformance fixtures.
+User-installed script plugins and external providers can extend its schemas and Operators through
+explicit grants; dynamically replacing the entire domain pack is deferred.
 
 This keeps FITS/XISF parsing and the initial UI contribution in the shipped artifact without making
 astro vocabulary part of core. Whether a later domain pack can be dynamically installed remains
@@ -69,11 +69,11 @@ Specific calls to make explicit:
 
 - Does core know the *concept* "session" (a Collection with a time span and a subject) with the pack supplying vocabulary, or is session entirely pack-defined?
 - Equipment: core, pack, or core concept with pack-defined spec facets?
-- Can a pack contribute frontend surface, or only API and facets? This gates whether M5 can proceed independently.
+- Can a pack contribute frontend surface, or only API and facets? This gates whether the frontend workstream can proceed independently.
 
 ## Decision
 
-The concrete crate skeleton (#228–#233) makes this seam physical, so ADR-002 is
+The concrete crate skeleton makes this seam physical, so it is
 decided now rather than deferred. All four calls below are taken in the
 reversible-safe direction — compiled-in → loadable, pack-owned → core, and
 API-only → UI-ABI are each additive later, while the reverse would be a
@@ -83,7 +83,7 @@ migration.
 `packs/astro` crate. It codes against the public `plugin-abi` contract — the same
 Source/Operator/Sink traits and registry a third-party pack would use — and never
 against `core` internals; that direction is enforced structurally (astro depends on
-`plugin-abi` only) and by a dependency-direction lint. The pack uses ADR-001's
+`plugin-abi` only) and by a dependency-direction lint. The pack uses the
 built-in Rust execution profile and implements the same semantic contracts and
 conformance fixtures a third party would. Dynamically replacing the whole domain
 pack is **deferred, not designed out**: the contract boundary exists today; only the
@@ -104,6 +104,6 @@ behaviour and facet schemas carrying render metadata (type, unit, label,
 filterability, render hint). The single TypeScript frontend renders facets
 generically; first-party astro views (sky map, visibility) live in the shared React
 app. There is **no dynamic frontend plugin ABI in v2.0**; dynamic UI contribution is
-deferred to M7+. This keeps M5 an independently-moving React app and is consistent
-with ADR-001's caution against a published dynamic ABI. Adding a UI-contribution
-mechanism later is purely additive.
+deferred until after cutover. This keeps the frontend an independently-moving React app
+and is consistent with the caution against a published dynamic ABI. Adding a
+UI-contribution mechanism later is purely additive.

--- a/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
+++ b/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
@@ -1,104 +1,55 @@
-# 003: Storage Layout, Asset Identity, and Content Revisions
+# 003: Asset Identity and Content Revisions
 
-**Status:** Accepted
-**Date:** 2026-07-29
+**Status:** Accepted · **Date:** 2026-07-29
+
 **Context:** This ADR settles the identity and versioning model that Lineage and Operation Runs depend on; it must be decided before the core spine is built.
 
 ## Problem
 
-Sidereal v2 becomes the system of record for files it renames, moves, and organises. Identity cannot
-be path-derived. A single mutable Asset record is also insufficient: if an operation rewrites bytes
-under a stable ID, the previous hash and state disappear and lineage cannot distinguish before from
-after.
+Sidereal v2 becomes the system of record for files it renames, moves, and organises, so identity cannot be path-derived. A single mutable Asset record is also insufficient: if an operation rewrites bytes under a stable ID, the previous hash and state disappear and lineage cannot distinguish before from after.
 
-The model must separately answer:
+The model must answer three coupled questions at once:
 
-1. What is the stable identity users, collections, and external mappings refer to?
+1. What is the stable identity that users, collections, and external mappings refer to?
 2. How are immutable byte states identified and retained for lineage and audit?
-3. Which changes create a new content revision?
-4. What is the user-visible and internal on-disk layout?
+3. Which changes create a new content revision versus mutating an existing one?
 
-## Options considered
+The on-disk tree and cross-filesystem move behaviour are a *separate* concern, decided in [ADR-011 — Storage tree layout & cross-filesystem moves](ADR-011-storage-tree-layout.md); this ADR fixes only the logical model those layout invariants attach to.
+
+## Options
 
 ### Option A: Mutable Asset with a surrogate ID
 
 An Asset has a stable ID and one current hash. Byte rewrites update the row.
 
-This keeps paths and references stable but destroys byte history. An edge from an Asset to itself
-cannot say which pre- and post-operation bytes participated.
+This keeps paths and references stable but destroys byte history. An edge from an Asset to itself cannot say which pre- and post-operation bytes participated.
 
 ### Option B: Content hash as Asset identity
 
 Every byte change creates a new Asset.
 
-This gives strong integrity but makes logical identity unstable, mixes mechanical revisions with
-scientifically meaningful assets, and forces collections and external mappings to chase replacements.
+This gives strong integrity but makes logical identity unstable, mixes mechanical revisions with scientifically meaningful assets, and forces collections and external mappings to chase replacements.
 
 ### Option C: Stable Asset plus immutable AssetVersion
 
-An Asset is the logical file identity. Each byte state is an immutable AssetVersion with a content
-hash. The Asset points to its current version; lineage and Operation Run inputs/outputs point to
-versions.
+An Asset is the logical file identity. Each byte state is an immutable AssetVersion with a content hash. The Asset points to its current version; lineage and Operation Run inputs/outputs point to versions.
 
 This adds one level to the model but preserves both stable user identity and exact byte provenance.
 
 ## Recommendation
 
-Choose **Option C**.
-
-### Identity and revision rules
+**Option C.** A alone loses byte history, so lineage can't tell before from after; B keeps integrity but makes logical identity chase every mechanical rewrite. C separates the two axes that are actually distinct — a stable identity users and collections hold, and immutable byte states lineage points at — at the cost of one extra level in the model. The direct rules that follow from C:
 
 - `Asset.id` is a stable opaque surrogate independent of path and content.
-- `AssetVersion.id` is an opaque identifier with a mandatory content hash, byte size, format, and
-  creation provenance. The hash has a unique/indexed role for dedup and integrity but is not the
-  user-facing primary key.
-- Lineage edges point from produced AssetVersions to the exact consumed AssetVersions.
-- Operation Run inputs and outputs also reference versions, making replay and audit unambiguous.
-- A rename or move changes an Asset path/location event and does not create a version because bytes
-  did not change.
-- Any byte change — including embedded FITS metadata or an XMP rewrite — creates a new immutable
-  AssetVersion. It may advance the current version of the same Asset or create a new Asset depending
-  on Operator intent, but the previous version remains addressable by history.
-- New scientific products such as thumbnails, masters, stacks, and exports are normally new Assets,
-  not merely versions of their inputs.
-- Core, not plugins, mints identities, computes hashes, advances current-version pointers, and writes
-  lineage.
+- `AssetVersion.id` is an opaque identifier with a mandatory content hash, byte size, format, and creation provenance. The hash is unique/indexed for dedup and integrity but is not the user-facing primary key.
+- Lineage edges and Operation Run inputs/outputs point from produced AssetVersions to the exact consumed AssetVersions, making replay and audit unambiguous.
+- A rename or move is a path/location event and does **not** create a version — bytes did not change.
+- Any byte change — including embedded FITS metadata or an XMP rewrite — creates a new immutable AssetVersion. It may advance the current version of the same Asset or create a new Asset depending on Operator intent; the previous version stays addressable by history.
+- New scientific products (thumbnails, masters, stacks, exports) are normally new Assets, not merely versions of their inputs.
+- Core, not plugins, mints identities, computes hashes, advances current-version pointers, and writes lineage.
 
-The retention policy for superseded versions is explicit and lineage-aware. A version referenced by
-lineage, an Operation Run, a hold, or migration audit cannot be garbage-collected. A later storage
-policy may prune unreferenced mechanical revisions after warning and backup checks.
-
-### Reconciliation
-
-Core hashes every asset version at ingest. If bytes change outside Sidereal, reconciliation does not
-silently update the known version. It records an integrity mismatch and requires an explicit adopt,
-restore, or ignore decision. Adopting creates a new version with out-of-band provenance.
-
-Missing paths mark an Asset unavailable; they do not delete identity, versions, or lineage. A found
-file can be re-associated by hash and additional safety checks.
-
-### Storage layout
-
-Identity does not prescribe layout. The exact on-disk tree and cross-filesystem move behavior are a
-separate decision — split out to [ADR-011 — Storage tree layout & cross-filesystem
-moves](ADR-011-storage-tree-layout.md), which carries the binding invariants (recoverable DB+FS updates,
-moves never rewrite content, historical versions never surface as duplicate current assets,
-path-traversal/symlink escape rejected, every file reconcilable to an AssetVersion + hash) and must be
-Accepted before storage code is written.
-
-### Version navigation and concurrency (DataHub comparison)
-
-A comparison against DataHub's aspect-versioning model confirmed the Option C shape, with these
-deliberate divergences from DataHub's moving `v0` sentinel:
-
-- The "current" selection is a separate `Asset.current_version_id` pointer, **not** a moving `v0`
-  sentinel; `isLatest` is **computed**, never a stored per-version boolean.
-- Navigation aids that are **metadata, not identity**: a dense per-Asset `version_seq` ordinal plus
-  optional curated `label` / `aliases` / `note`.
-- Advancing the current pointer uses **optimistic concurrency** — compare-and-swap guarded by an
-  `Asset.revision` counter.
+Retention is lineage-aware: a version referenced by lineage, an Operation Run, a hold, or migration audit cannot be garbage-collected. A later storage policy may prune unreferenced mechanical revisions after warning and backup checks.
 
 ## Decision
 
-Accepted 2026-08-18 — **Option C**, as recommended (identity and versioning only). On-disk tree layout
-and cross-filesystem moves are decided separately in the storage-tree decision above.
+Accepted 2026-08-18 — **Option C, as recommended** (identity and versioning only). The current-version pointer, computed-latest, and concurrency mechanics that implement C are recorded as design facts in [the architecture overview](../architecture/README.md#design-facts). On-disk tree layout, cross-filesystem moves, and the integrity-reconciliation protocol are decided separately in [ADR-011](ADR-011-storage-tree-layout.md).

--- a/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
+++ b/docs/decisions/ADR-003-storage-layout-and-asset-identity.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The outcome constrains the [Lineage](../architecture/README.md#core-concepts) model and must be decided before M1 builds the core spine.
+**Context:** This ADR settles the identity and versioning model that Lineage and Operation Runs depend on; it must be decided before the core spine is built.
 
 ## Problem
 
@@ -80,15 +80,16 @@ file can be re-associated by hash and additional safety checks.
 ### Storage layout
 
 Identity does not prescribe layout. The exact on-disk tree and cross-filesystem move behavior are a
-separate decision — split out to [ADR-011](ADR-011-storage-tree-layout.md), which carries the binding
-invariants (recoverable DB+FS updates, moves never rewrite content, historical versions never surface as
-duplicate current assets, path-traversal/symlink escape rejected, every file reconcilable to an
-AssetVersion + hash) and must be Accepted before M1 storage design.
+separate decision — split out to [ADR-011 — Storage tree layout & cross-filesystem
+moves](ADR-011-storage-tree-layout.md), which carries the binding invariants (recoverable DB+FS updates,
+moves never rewrite content, historical versions never surface as duplicate current assets,
+path-traversal/symlink escape rejected, every file reconcilable to an AssetVersion + hash) and must be
+Accepted before storage code is written.
 
-### Version navigation and concurrency (input from #217 / DataHub)
+### Version navigation and concurrency (DataHub comparison)
 
-A [#217](https://github.com/sidereal-io/sidereal/issues/217) / DataHub comparison confirmed the Option C
-shape, with these deliberate divergences from DataHub's moving `v0` sentinel:
+A comparison against DataHub's aspect-versioning model confirmed the Option C shape, with these
+deliberate divergences from DataHub's moving `v0` sentinel:
 
 - The "current" selection is a separate `Asset.current_version_id` pointer, **not** a moving `v0`
   sentinel; `isLatest` is **computed**, never a stored per-version boolean.
@@ -99,6 +100,5 @@ shape, with these deliberate divergences from DataHub's moving `v0` sentinel:
 
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213) — **Option C**, as recommended (identity and versioning only).
-On-disk tree layout and cross-filesystem moves are decided separately in
-[ADR-011](ADR-011-storage-tree-layout.md) (Proposed), which gates M1.
+Accepted 2026-08-18 — **Option C**, as recommended (identity and versioning only). On-disk tree layout
+and cross-filesystem moves are decided separately in the storage-tree decision above.

--- a/docs/decisions/ADR-004-database-engine-and-schema.md
+++ b/docs/decisions/ADR-004-database-engine-and-schema.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The [facet mechanism](../architecture/README.md#core-and-domain-packs) imposes concrete requirements on the store; this ADR picks the engine and schema approach that satisfy them.
+**Context:** The facet mechanism imposes concrete requirements on the store — indexed lookup on semi-structured facet values and recursive lineage traversal; this ADR picks the engine and schema approach that satisfy them.
 
 ## Problem
 
@@ -64,7 +64,7 @@ Also decide here:
 
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213). **Option C — PostgreSQL-only.** This **reverses both** the RFC's
+Accepted 2026-08-18. **Option C — PostgreSQL-only.** This **reverses both** the RFC's
 leaning (B) and this ADR's own Recommendation (A) — deliberately. One server-grade engine gives the
 strongest facet indexing (JSONB + GIN), the best recursive-CTE performance for lineage, and real
 concurrency under bursty ingest, and it eliminates the whole class of problems the analysis package
@@ -75,8 +75,8 @@ into v2.
 **Deployment trade-off, mitigated at the packaging layer.** Option C's rejection ground was that it
 forces every self-hoster to run a database server. We accept that and neutralize it in packaging, not
 schema: v2 ships an **all-in-one Docker image** and/or a **docker-compose bundle** that stands Postgres
-up alongside the app. The install stays effectively one command; M6 requirements (port 5000, volume
-mounts, PUID/PGID, healthcheck) are preserved, with the data volume now backing Postgres. Backup docs
+up alongside the app. The install stays effectively one command; the cutover requirements (port 5000,
+volume mounts, PUID/PGID, healthcheck) are preserved, with the data volume now backing Postgres. Backup docs
 cover the Postgres volume and `pg_dump` in place of the old file copy.
 
 **Coupled calls settled here:**

--- a/docs/decisions/ADR-004-database-engine-and-schema.md
+++ b/docs/decisions/ADR-004-database-engine-and-schema.md
@@ -1,7 +1,7 @@
 # 004: Database Engine and Schema Strategy
 
-**Status:** Accepted
-**Date:** 2026-07-29
+**Status:** Accepted · **Date:** 2026-07-29
+
 **Context:** The facet mechanism imposes concrete requirements on the store — indexed lookup on semi-structured facet values and recursive lineage traversal; this ADR picks the engine and schema approach that satisfy them.
 
 ## Problem

--- a/docs/decisions/ADR-005-frontend-continuity.md
+++ b/docs/decisions/ADR-005-frontend-continuity.md
@@ -1,7 +1,7 @@
 # 005: Frontend Continuity
 
-**Status:** Accepted
-**Date:** 2026-07-29
+**Status:** Accepted · **Date:** 2026-07-29
+
 **Context:** The frontend workstream runs in parallel with the backend rewrite — the single most important scheduling decision in the plan. This ADR decides what that workstream starts *from*.
 
 ## Problem

--- a/docs/decisions/ADR-005-frontend-continuity.md
+++ b/docs/decisions/ADR-005-frontend-continuity.md
@@ -1,6 +1,6 @@
 # 005: Frontend Continuity
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-29
 **Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). M5 (frontend parity) starts at M1 and runs in parallel with the backend rewrite — the RFC calls this "the single most important scheduling decision in the plan." This ADR decides what M5 starts *from*.
 
@@ -61,4 +61,21 @@ Two conditions:
 
 ## Decision
 
-[Filled in after review.]
+Accepted 2026-08-20 (M0 of RFC #213) — **Option C: new shell, port components.** The data layer is
+rewritten under every option, so the real question is only what happens to the presentational
+components. C keeps the expensive, working pieces (deep-zoom viewer, Aladin sky map, admin forms) and
+takes structural freedom in the routing, data layer, and information architecture — the layer where the
+asset/collection/lineage model actually reshapes the UI. A and B are both dominated: A contorts the new
+model into an Immich-mirror shell; B rebuilds working UI for no product gain.
+
+**Two conditions bind the M5 *build*, not this direction-setting call:**
+
+1. **The contributor conversation happens before M5 frontend work starts in earnest** — this is the
+   most visible decision to the frontend workstream and the RFC's named mitigation for its top risk.
+2. **A green v0.10.x Playwright baseline is established first** (`Q14`, `OQ-16`), so per-component
+   "port vs. rewrite" judgments rest on a runnable parity harness.
+
+**Consequence for M1:** the minimal read-only view M1 needs for its exit criterion is built as the
+**first screen of this new Option-C shell** (a fresh Vite/React/Tailwind app scaffold, read-only asset
+list + detail), not throwaway work — M5 grows the same shell. The two conditions above still gate the
+broader M5 parity build, not this minimal first screen.

--- a/docs/decisions/ADR-005-frontend-continuity.md
+++ b/docs/decisions/ADR-005-frontend-continuity.md
@@ -61,21 +61,8 @@ Two conditions:
 
 ## Decision
 
-Accepted 2026-08-20 (M0 of RFC #213) — **Option C: new shell, port components.** The data layer is
-rewritten under every option, so the real question is only what happens to the presentational
-components. C keeps the expensive, working pieces (deep-zoom viewer, Aladin sky map, admin forms) and
-takes structural freedom in the routing, data layer, and information architecture — the layer where the
-asset/collection/lineage model actually reshapes the UI. A and B are both dominated: A contorts the new
-model into an Immich-mirror shell; B rebuilds working UI for no product gain.
+Accepted 2026-08-20 (M0 of RFC #213) — **Option C, as recommended**, including its two conditions
+(contributor conversation; green v0.10.x E2E baseline) as gates on the M5 build, not on this decision.
 
-**Two conditions bind the M5 *build*, not this direction-setting call:**
-
-1. **The contributor conversation happens before M5 frontend work starts in earnest** — this is the
-   most visible decision to the frontend workstream and the RFC's named mitigation for its top risk.
-2. **A green v0.10.x Playwright baseline is established first** (`Q14`, `OQ-16`), so per-component
-   "port vs. rewrite" judgments rest on a runnable parity harness.
-
-**Consequence for M1:** the minimal read-only view M1 needs for its exit criterion is built as the
-**first screen of this new Option-C shell** (a fresh Vite/React/Tailwind app scaffold, read-only asset
-list + detail), not throwaway work — M5 grows the same shell. The two conditions above still gate the
-broader M5 parity build, not this minimal first screen.
+Consequence for M1 (#217): the minimal read-only view is the first screen of the new shell, not
+throwaway work.

--- a/docs/decisions/ADR-005-frontend-continuity.md
+++ b/docs/decisions/ADR-005-frontend-continuity.md
@@ -2,15 +2,15 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). M5 (frontend parity) starts at M1 and runs in parallel with the backend rewrite — the RFC calls this "the single most important scheduling decision in the plan." This ADR decides what M5 starts *from*.
+**Context:** The frontend workstream runs in parallel with the backend rewrite — the single most important scheduling decision in the plan. This ADR decides what that workstream starts *from*.
 
 ## Problem
 
-The frontend stays TypeScript/React either way; that is settled and is what keeps existing frontend contributors productive through a backend language switch. The question is whether M5 evolves `apps/client` against the new API or starts fresh.
+The frontend stays TypeScript/React either way; that is settled and is what keeps existing frontend contributors productive through a backend language switch. The question is whether the frontend workstream evolves `apps/client` against the new API or starts fresh.
 
 The v2 API is not compatible with v0.10.x — different data model, different resources. So "evolve" does not mean "keep working throughout"; it means "keep the codebase, rewrite the data layer." The existing client is React 19 + Vite + Tailwind 4 + shadcn/ui + TanStack Query + Wouter, with pages for gallery, targets, equipment, plate solving, sky map, locations, and admin.
 
-This decision is also entangled with a **human** factor the RFC names as its top risk: the project's second-largest contributor works in TypeScript. Whichever option is chosen should be chosen *with* them, not for them.
+This decision is also entangled with a **human** factor that is the project's top risk: the project's second-largest contributor works in TypeScript. Whichever option is chosen should be chosen *with* them, not for them.
 
 ## Options
 
@@ -18,7 +18,7 @@ This decision is also entangled with a **human** factor the RFC names as its top
 
 **Pros:**
 - Keeps the component library, styling system, deep-zoom viewer, Aladin sky-map integration, and form patterns — genuinely expensive, working pieces.
-- Contributors keep working in a codebase they know from day one of M1.
+- Contributors keep working in a codebase they know from day one of the frontend build.
 - Cutover parity is a diff against something real rather than a from-scratch build.
 - The existing Playwright suite stays meaningfully runnable against it.
 
@@ -36,7 +36,7 @@ This decision is also entangled with a **human** factor the RFC names as its top
 **Cons:**
 - Rebuilds working, non-trivial UI (deep zoom, Aladin, admin forms) for no product gain.
 - Two frontends during the transition, or a long gap with nothing demoable.
-- The RFC's parallelism benefit shrinks — M5 becomes a bigger effort with a later first demo.
+- The parallelism benefit shrinks — the frontend becomes a bigger effort with a later first demo.
 
 ### Option C: New shell, port components
 
@@ -56,13 +56,12 @@ Fresh application shell, routing, and data layer; migrate presentational compone
 
 Two conditions:
 
-1. **Have the contributor conversation first.** This decision is the most visible one to the frontend workstream, and the RFC's own mitigation for its top risk is to talk before M0 starts.
+1. **Have the contributor conversation first.** This decision is the most visible one to the frontend workstream, and the mitigation for that top risk is to talk before the rewrite starts.
 2. **Get a green E2E baseline on v0.10.x before deciding.** The analysis package notes the Playwright suite was never executed (`Q14`, `OQ-16`), and no CI workflow references it. Whether the existing suite is a usable parity harness materially affects A vs. C, and right now nobody knows.
 
 ## Decision
 
-Accepted 2026-08-20 (M0 of RFC #213) — **Option C, as recommended**, including its two conditions
-(contributor conversation; green v0.10.x E2E baseline) as gates on the M5 build, not on this decision.
+Accepted 2026-08-20 — **Option C, as recommended**, including its two conditions (contributor
+conversation; green v0.10.x E2E baseline) as gates on the frontend build, not on this decision.
 
-Consequence for M1 (#217): the minimal read-only view is the first screen of the new shell, not
-throwaway work.
+Consequence: the first minimal read-only view is the first screen of the new shell, not throwaway work.

--- a/docs/decisions/ADR-006-rule-engine-deferral.md
+++ b/docs/decisions/ADR-006-rule-engine-deferral.md
@@ -1,7 +1,7 @@
 # 006: Declarative Processing, Selectors, and Policy Deferral
 
-**Status:** Accepted
-**Date:** 2026-07-31
+**Status:** Accepted · **Date:** 2026-07-31
+
 **Context:** Establishes declarative, convergent processing while deferring user-authored policy rules
 until after cutover. Facet mechanics are owned separately by [ADR-008 — Metadata envelope, facets &
 write authority](ADR-008-facet-schema-and-write-authority.md).

--- a/docs/decisions/ADR-006-rule-engine-deferral.md
+++ b/docs/decisions/ADR-006-rule-engine-deferral.md
@@ -2,9 +2,9 @@
 
 **Status:** Accepted
 **Date:** 2026-07-31
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). Establishes
-declarative, convergent processing in M2 while deferring user-authored policy rules until
-post-cutover (M7+).
+**Context:** Establishes declarative, convergent processing while deferring user-authored policy rules
+until after cutover. Facet mechanics are owned separately by [ADR-008 — Metadata envelope, facets &
+write authority](ADR-008-facet-schema-and-write-authority.md).
 
 ## Problem
 
@@ -21,8 +21,8 @@ A workflow or pipeline makes the execution path the durable abstraction. That cr
 problem: when execution stops, the user must diagnose where a workflow cursor is stuck and decide
 how to move it. It also bakes an ordering into policy even when the order is incidental.
 
-An `Operation Run` remains the exact historical record of one Operator attempt. M2 needs a model for
-the desired state above those attempts without becoming a general-purpose workflow engine. It also
+An `Operation Run` remains the exact historical record of one Operator attempt. This decision needs a
+model for the desired state above those attempts without becoming a general-purpose workflow engine. It also
 needs one answer to three applicability questions: which subjects receive a policy, which Operators
 can process a subject, and which assets belong to a dynamic Collection.
 
@@ -80,7 +80,7 @@ Every trigger or button directly invokes one Operator; compound processing is co
 
 **Pros:**
 
-- Smallest M2 implementation.
+- Smallest initial implementation.
 
 **Cons:**
 
@@ -90,7 +90,7 @@ Every trigger or button directly invokes one Operator; compound processing is co
 
 ## Decision
 
-**Accepted Option A.** M2 implements shared Selectors, declarative Processing Goals, and
+**Accepted Option A.** It implements shared Selectors, declarative Processing Goals, and
 reconciliation. It does not introduce a general-purpose workflow engine or a first-class Pipeline
 Run.
 
@@ -103,8 +103,7 @@ The following semantics are part of the decision:
    arbitrary plugin code.
 2. **Facets are the extensible selection metadata.** Facet schemas declare type, scope, mutability,
    indexing, ownership, and provenance. Built-in policies reference canonical core or domain-pack
-   schemas rather than producer-specific fields. [ADR-008](ADR-008-facet-schema-and-write-authority.md)
-   owns the full contract.
+   schemas rather than producer-specific fields; the facet contract is owned separately.
 3. **Sources classify; they do not orchestrate.** Source configuration may assign an initial `kind`
    and configured facets. A Source may propose detected facets within its grants, but never selects
    or invokes Operators. Mixed-kind Sources may classify per asset rather than declaring one fixed
@@ -136,10 +135,10 @@ The following semantics are part of the decision:
 14. **Manual actions add goals.** Button clicks and API requests use the same machinery rather than
     bypassing reconciliation with a separate execution path.
 
-M3 must prove convergence with configured Source facets and a built-in astro policy covering a
-realistic ingest flow. The system must explain policy and Operator matches, recover after a
+Bringing up the astro pack must prove convergence with configured Source facets and a built-in astro
+policy covering a realistic ingest flow. The system must explain policy and Operator matches, recover after a
 deliberately dropped event and a process crash, avoid duplicating a successful external effect, and
 identify an impossible goal without leaving opaque “stuck” work.
 
 User-authored policy matching, conflict resolution, simulation, explanation UI, and policy editing
-remain deferred to M7+. Built-in domain-pack policies provide the required pre-cutover behaviour.
+remain deferred until after cutover. Built-in domain-pack policies provide the required pre-cutover behaviour.

--- a/docs/decisions/ADR-007-security-and-plugin-trust.md
+++ b/docs/decisions/ADR-007-security-and-plugin-trust.md
@@ -1,7 +1,7 @@
 # 007: Security and Plugin Trust Model
 
-**Status:** Accepted
-**Date:** 2026-07-30
+**Status:** Accepted · **Date:** 2026-07-30
+
 **Context:** v2 adds filesystem mutation, plugin execution, external providers, and scoped secret
 delivery; the current unauthenticated/CORS-open posture cannot be carried forward implicitly. Coupled
 with [ADR-001 — Plugin contract & execution profiles](ADR-001-plugin-boundary.md): that decision says

--- a/docs/decisions/ADR-007-security-and-plugin-trust.md
+++ b/docs/decisions/ADR-007-security-and-plugin-trust.md
@@ -2,14 +2,15 @@
 
 **Status:** Accepted
 **Date:** 2026-07-30
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). v2 adds filesystem
-mutation, plugin execution, external providers, and scoped secret delivery. The current
-unauthenticated/CORS-open posture cannot be carried forward implicitly.
+**Context:** v2 adds filesystem mutation, plugin execution, external providers, and scoped secret
+delivery; the current unauthenticated/CORS-open posture cannot be carried forward implicitly. Coupled
+with [ADR-001 — Plugin contract & execution profiles](ADR-001-plugin-boundary.md): that decision says
+how plugin code runs, this one says what it may do.
 
 ## Problem
 
 v2 becomes the system of record for user files and can invoke code that reads assets, publishes
-externally, and requests secrets. Before M1 touches a real filesystem, the architecture must define who
+externally, and requests secrets. Before any code touches a real filesystem, the architecture must define who
 may use the HTTP and WebSocket APIs, which actions need elevated authority, whether a plugin is trusted
 and which capabilities it receives, how external-provider endpoints authenticate, how secrets are
 stored/delivered/logged/revoked, and which browser origins may issue authenticated requests. Treating
@@ -77,12 +78,11 @@ caller and C funds a multi-user sharing surface v2.0 does not need. The requirem
 
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213) — **Option B**, as recommended. The M0 exit criteria below are
-binding.
+Accepted 2026-08-18 — **Option B**, as recommended. The exit criteria below are binding.
 
-## M0 exit criteria
+## Exit criteria
 
-Binding — M1 cannot begin until:
+Binding — implementation cannot begin until:
 
 1. the application authentication mode and initial-setup flow are selected;
 2. HTTP, WebSocket, CORS, and CSRF behavior are specified and covered by integration tests;

--- a/docs/decisions/ADR-008-facet-schema-and-write-authority.md
+++ b/docs/decisions/ADR-008-facet-schema-and-write-authority.md
@@ -2,8 +2,8 @@
 
 **Status:** Accepted
 **Date:** 2026-08-01
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). Selectors need a
-portable metadata contract, while domain packs and alternative plugins need interoperable typed values.
+**Context:** Selectors need a portable metadata contract, while domain packs and alternative plugins
+need interoperable typed values.
 
 ## Problem
 
@@ -81,13 +81,13 @@ provenance; domain policy selects the current value. Breaking changes need a new
 declared migration; removing a schema owner makes it unavailable for new writes without deleting stored
 values.
 
-**Mutable-facet audit history (#217 / DataHub) is out of scope for v2.0 / M1.** M1's facets are
-write-once observations; a mutable intent facet (`core.processing.mode`) overwrites in place, keeping
-only last-write provenance — not a value trail. A full immutable audit trail is deferred post-cutover
-and, if adopted, reuses [ADR-003](ADR-003-storage-layout-and-asset-identity.md)'s immutable-version
-pattern rather than inventing a second mechanism.
+**Mutable-facet audit history is out of scope for v2.0.** The first release's facets are write-once
+observations; a mutable intent facet (`core.processing.mode`) overwrites in place, keeping only
+last-write provenance — not a value trail. A full immutable audit trail is deferred until after cutover
+and, if adopted, reuses [ADR-003 — Storage layout & asset
+identity](ADR-003-storage-layout-and-asset-identity.md)'s immutable-version pattern rather than inventing
+a second mechanism.
 
 ## Decision
 
-Accepted 2026-08-18 (M0 of RFC #213) — **small core-owned envelope plus facets, Option C**, as
-recommended.
+Accepted 2026-08-18 — **small core-owned envelope plus facets, Option C**, as recommended.

--- a/docs/decisions/ADR-008-facet-schema-and-write-authority.md
+++ b/docs/decisions/ADR-008-facet-schema-and-write-authority.md
@@ -1,7 +1,7 @@
 # 008: Metadata Envelope, Facets, and Write Authority
 
-**Status:** Accepted
-**Date:** 2026-08-01
+**Status:** Accepted · **Date:** 2026-08-01
+
 **Context:** Selectors need a portable metadata contract, while domain packs and alternative plugins
 need interoperable typed values.
 
@@ -84,8 +84,8 @@ values.
 **Mutable-facet audit history is out of scope for v2.0.** The first release's facets are write-once
 observations; a mutable intent facet (`core.processing.mode`) overwrites in place, keeping only
 last-write provenance — not a value trail. A full immutable audit trail is deferred until after cutover
-and, if adopted, reuses [ADR-003 — Storage layout & asset
-identity](ADR-003-storage-layout-and-asset-identity.md)'s immutable-version pattern rather than inventing
+and, if adopted, reuses [ADR-003 — Asset identity & content
+revisions](ADR-003-storage-layout-and-asset-identity.md)'s immutable-version pattern rather than inventing
 a second mechanism.
 
 ## Decision

--- a/docs/decisions/ADR-009-backend-language.md
+++ b/docs/decisions/ADR-009-backend-language.md
@@ -1,7 +1,7 @@
 # 009: Backend Language and Runtime
 
-**Status:** Accepted
-**Date:** 2026-08-19
+**Status:** Accepted · **Date:** 2026-08-19
+
 **Context:** The v2 rewrite needs a backend language; this ADR records *why it is Rust* rather than
 leaving the single most expensive-to-reverse decision undocumented.
 
@@ -41,7 +41,7 @@ Reversing this later means a second rewrite, so it is decided explicitly and up 
 - Native hot-path performance for FITS/XISF parsing and hashing; mature image/numeric crates.
 - Compile-time memory and data-race safety on the component that renames, moves, and deletes originals.
 - Fearless concurrency for parallel ingest with no GC-pause tail.
-- Mature embeddable scripting (Rhai) and a clean capability-limited `AssetContext`, matching the plugin execution model.
+- A mature embeddable-scripting ecosystem and a clean capability-limited `AssetContext`, matching the plugin execution model.
 - Single static binary, supporting the one-command deployment goal.
 
 **Cons:**
@@ -55,8 +55,8 @@ Reversing this later means a second rewrite, so it is decided explicitly and up 
 
 **Cons:**
 - Weaker than Rust for CPU-bound numeric/parsing work, and still GC-paused.
-- A less expressive type system for the Asset/Version/Lineage/facet model, and no
-  Rhai-in-process-caliber embedding story.
+- A less expressive type system for the Asset/Version/Lineage/facet model, and a weaker
+  in-process embeddable-scripting story.
 
 ## Recommendation
 

--- a/docs/decisions/ADR-009-backend-language.md
+++ b/docs/decisions/ADR-009-backend-language.md
@@ -2,9 +2,8 @@
 
 **Status:** Accepted
 **Date:** 2026-08-19
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). The RFC commits to a
-backend rewrite; this ADR records *why the rewrite is in Rust* rather than leaving the single most
-expensive-to-reverse decision documented only by the RFC title.
+**Context:** The v2 rewrite needs a backend language; this ADR records *why it is Rust* rather than
+leaving the single most expensive-to-reverse decision undocumented.
 
 ## Problem
 
@@ -17,9 +16,9 @@ TypeScript/Hono stack serves weakly:
   irreplaceable user data.
 - **Concurrency under bursty ingest** without GC-pause tail latency.
 - **A credible plugin-isolation story** — an embeddable script engine and capability limits, with no
-  published dynamic ABI ([ADR-001](ADR-001-plugin-boundary.md)).
+  published dynamic ABI.
 
-Reversing this after M1 means a second rewrite, so it is decided explicitly and up front.
+Reversing this later means a second rewrite, so it is decided explicitly and up front.
 
 ## Options
 
@@ -27,7 +26,7 @@ Reversing this after M1 means a second rewrite, so it is decided explicitly and 
 
 **Pros:**
 - Keeps the existing backend, its contributors, and one language across the whole stack.
-- Fastest path to a running M1.
+- Fastest path to a running backend.
 
 **Cons:**
 - CPU-bound FITS parsing and hashing push the real work into native addons or WASM anyway, so the
@@ -42,7 +41,7 @@ Reversing this after M1 means a second rewrite, so it is decided explicitly and 
 - Native hot-path performance for FITS/XISF parsing and hashing; mature image/numeric crates.
 - Compile-time memory and data-race safety on the component that renames, moves, and deletes originals.
 - Fearless concurrency for parallel ingest with no GC-pause tail.
-- Mature embeddable scripting (Rhai) and a clean capability-limited `AssetContext`, matching ADR-001.
+- Mature embeddable scripting (Rhai) and a clean capability-limited `AssetContext`, matching the plugin execution model.
 - Single static binary, supporting the one-command deployment goal.
 
 **Cons:**
@@ -67,13 +66,12 @@ maturity pay off and where Node's strengths do not apply. Go is closer than Node
 performance and type expressiveness for a domain model that leans on both.
 
 The language switch is the RFC's top risk, mitigated deliberately: **the frontend stays TypeScript/React**
-and moves as an independent workstream from M1, so existing contributors stay productive through the
-switch ([ADR-005](ADR-005-frontend-continuity.md)); and **heavy or OS-specific work stays out of the Rust
-core** — Python ML, Siril/PixInsight/ASTAP run as external providers behind the plugin contract
-([ADR-001](ADR-001-plugin-boundary.md)), so choosing Rust for core does not force every integration into
-Rust. This decision fixes the language, not the framework/crate stack (web server, async runtime, image
+and moves as an independent workstream, so existing contributors stay productive through the switch;
+and **heavy or OS-specific work stays out of the Rust core** — Python ML, Siril/PixInsight/ASTAP run as
+external providers behind the plugin contract, so choosing Rust for core does not force every
+integration into Rust. This decision fixes the language, not the framework/crate stack (web server, async runtime, image
 libraries); those are ordinary implementation choices settled in code.
 
 ## Decision
 
-Accepted 2026-08-19 (M0 of RFC #213) — **Rust**, as recommended.
+Accepted 2026-08-19 — **Rust**, as recommended.

--- a/docs/decisions/ADR-010-migration-strategy.md
+++ b/docs/decisions/ADR-010-migration-strategy.md
@@ -2,18 +2,17 @@
 
 **Status:** Accepted
 **Date:** 2026-08-19
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). v2 is a new data
-model; existing v0.10.x users have live data and files. This ADR records *how they reach v2*, and why
-that path knowingly overrides the analysis package's compatibility requirements. The operational detail
-lives in [migration.md](../architecture/migration.md).
+**Context:** v2 is a new data model; existing v0.10.x users have live data and files. This ADR records
+*how they reach v2*, and why that path knowingly overrides the analysis package's compatibility
+requirements. It coordinates with the PostgreSQL-only engine decision ([ADR-004 — Database engine &
+schema strategy](ADR-004-database-engine-and-schema.md)).
 
 ## Problem
 
 v0.10.x users hold real data — Immich-mirrored images, plate solves, equipment, acquisitions, saved
 locations — in a SQLite/Postgres database and a storage tree laid out as
 `{STORAGE_PATH}/processed/{id % 1000}/{id}/…`. v2's model is fundamentally different: stable Assets with
-immutable content-addressed Versions, Collections, facets, lineage, on Postgres only
-([ADR-003](ADR-003-storage-layout-and-asset-identity.md), [ADR-004](ADR-004-database-engine-and-schema.md)).
+immutable content-addressed Versions, Collections, facets, and lineage, on Postgres only.
 
 The analysis package (`13-compatibility-requirements.md`) states a replacement **MUST** preserve image
 IDs, that storage layout, every API path and shape, and reconciling-sync semantics. Those requirements
@@ -66,8 +65,8 @@ Run v2 alongside v0.10.x and migrate incrementally, resource by resource.
 
 ## Recommendation
 
-**Option B — clean break with a one-way importer**, gated on the non-negotiable cutover feature set in
-[migration.md](../architecture/migration.md). The MUST-preserve-compatibility requirements are not a
+**Option B — clean break with a one-way importer**, gated on a non-negotiable cutover feature set. The
+MUST-preserve-compatibility requirements are not a
 neutral constraint; they encode the exact architecture v2 replaces, so honouring them (A) forecloses the
 rewrite, and a strangler (C) pays dual-stack cost indefinitely for a product with one user and one
 maintainer. A bounded importer that is honest about what it drops is the proportionate path.
@@ -76,17 +75,17 @@ maintainer. A bounded importer that is honest about what it drops is the proport
   valuable as a behavioural inventory and as the source of the cutover gate, but v2 is not bound by its
   ID/layout/API-shape preservation requirements.
 - **Both SQLite and Postgres v0.10.x installs** reach v2 through the importer, not in-place dialect
-  migration ([ADR-004](ADR-004-database-engine-and-schema.md)).
+  migration.
 - **The importer is read-only against the source tree**, supports dry-run and resumable execution,
   records legacy-ID mappings, verifies checksums, and reconciles counts. Its hard invariant: every
   irreplaceable original is either imported and verified or named in the failure report — an unaccounted
   original blocks cutover.
-- **Rollback** is disposable-root discard before M6 and restore-from-verified-backup after; the importer
-  stays one-way by design.
+- **Rollback** is disposable-root discard before cutover and restore-from-verified-backup after; the
+  importer stays one-way by design.
 
-The full checklist, compatibility-break list, filesystem-safety rules, and rollback detail live in
-[migration.md](../architecture/migration.md); this ADR owns the decision, that doc owns the execution.
+The full checklist, compatibility-break list, filesystem-safety rules, and rollback detail are
+maintained separately as cutover execution; this ADR owns the decision.
 
 ## Decision
 
-Accepted 2026-08-19 (M0 of RFC #213) — **clean break with a one-way importer**, as recommended.
+Accepted 2026-08-19 — **clean break with a one-way importer**, as recommended.

--- a/docs/decisions/ADR-010-migration-strategy.md
+++ b/docs/decisions/ADR-010-migration-strategy.md
@@ -1,7 +1,7 @@
 # 010: Migration Strategy — Clean Break with a One-Way Importer
 
-**Status:** Accepted
-**Date:** 2026-08-19
+**Status:** Accepted · **Date:** 2026-08-19
+
 **Context:** v2 is a new data model; existing v0.10.x users have live data and files. This ADR records
 *how they reach v2*, and why that path knowingly overrides the analysis package's compatibility
 requirements. It coordinates with the PostgreSQL-only engine decision ([ADR-004 — Database engine &

--- a/docs/decisions/ADR-011-storage-tree-layout.md
+++ b/docs/decisions/ADR-011-storage-tree-layout.md
@@ -37,26 +37,92 @@ Whatever layout and move strategy are chosen must satisfy:
 
 ## Options
 
-*(Sketched to frame the decision; to be developed with the operator when M1 storage design opens.)*
+Two independent choices: the **tree shape** (A vs B) and how the byte store **addresses** a version.
 
 ### Option A: Single user-meaningful tree
 
 Originals and current renditions live in one tree organised by target/session/date; superseded versions
-are marked in the database but not surfaced as separate current files.
+are flagged in the database but not surfaced as separate current files.
 
-### Option B: Split browsable + protected internal subtree
+- **Pro:** what the user browses on disk *is* the managed tree — no indirection.
+- **Con:** the organizing keys (target, session, date) are astro **facets** that do not exist until M3,
+  and the tree must be addressable *now* (M1). It couples the physical store to domain vocabulary the
+  core is supposed to stay ignorant of, and every rename/move rewrites where real bytes live — the exact
+  operation most at risk from a crash.
 
-User-visible originals live in a browsable tree; derived renditions and superseded versions live in a
-separate internal subtree the UI never presents as current assets.
+### Option B: Split — protected internal object store + browsable projection
 
-Cross-filesystem moves, under either option, are likely **copy → verify hash → atomically swap the
-reference → reclaim the source**, rather than a non-atomic `rename` across devices — but the exact
-protocol and its crash-recovery steps are part of what this ADR must decide.
+The bytes of every `AssetVersion` (originals, renditions, superseded alike) live in a protected internal
+store the UI never lists. A separate **browsable** tree organised by target/session/date is a
+*projection* over that store, materialized later (M2/M3) when organize/move operators and astro facets
+exist. A user-visible move is a projection operation; it never rewrites the stored bytes.
+
+- **Pro:** the internal store is domain-agnostic and stable; user-visible reorganisation can never
+  corrupt byte truth; M1 builds only the internal store and defers the projection cleanly.
+- **Con:** two layers, and the projection's materialization mechanism (symlink / hardlink / reflink /
+  copy) is a later sub-decision.
+
+### Addressing the internal store: opaque-id vs content-hash
+
+Independently of A/B, the internal store can name a version file by its **opaque UUID** or by its
+**BLAKE3 content hash** (git-object style). Content-hash naming gives uniform directory fan-out by
+construction (a night's session spreads evenly, where a time-ordered UUID prefix would cluster), free
+content dedup, immutable-friendly files, and self-reconciliation (the filename *is* the hash). Its cost
+is that the path is opaque to a human starting from a UI id — mitigated by storing and surfacing the
+`storage_path`/`content_hash` mapping as read-only metadata ([#217](https://github.com/sidereal-io/sidereal/issues/217),
+per ADR-008) — and hash-refcounted GC.
 
 ## Recommendation
 
-*(To be filled in with the operator during M1 design.)*
+**Option B, with the internal object store content-addressed by BLAKE3.**
+
+**Internal object store** — the only part M1 builds:
+
+```
+{STORAGE_ROOT}/
+  store/{h[0:2]}/{h[2:4]}/{h}   # h = hex BLAKE3 of the version's bytes
+  tmp/{uuid}                     # ingest staging, same filesystem as store/
+```
+
+- **Atomic ingest:** copy the candidate into `tmp/` (**copy, never move** — filesystem-safety per
+  [migration.md](../architecture/migration.md)); BLAKE3-hash, stat, sniff format; **dedup by hash** (an
+  existing hash shares the file); `fsync`; **atomic `rename` into `store/`**; then commit the DB row.
+  Commit-last ordering means a crash leaves at worst an orphan `tmp/` file (swept on startup), never a DB
+  row pointing at nothing.
+- **Integrity reconciliation** (identity/versioning rules in [ADR-003](ADR-003-storage-layout-and-asset-identity.md)):
+  re-hash on a `verify` pass; a mismatch is recorded (`integrity_mismatch`) and needs an explicit
+  adopt/restore/ignore, never a silent update; a missing file marks the Asset unavailable without
+  deleting identity/versions/lineage.
+- **Path safety:** every path canonicalized and asserted under `STORAGE_ROOT`; `..` traversal and symlink
+  escape rejected.
+- **GC:** hash-**refcounted** — a stored file is deletable only when no `asset_version`, lineage edge,
+  Operation Run, hold, or migration audit references its hash (ADR-003 retention). M1 records references;
+  it does not garbage-collect.
+
+**Browsable projection** — *deferred, not M1:* a target/session/date tree materialized as links over the
+object store, built when organize/move operators and astro facets land (M2/M3). Because it is a
+projection, a user-visible move/rename changes only the projection, never the stored bytes. The
+materialization mechanism (symlink / hardlink / reflink / copy) is settled then; whichever is chosen,
+bytes are preserved.
+
+**Cross-filesystem moves** — *deferred, not M1:* when a user-visible move must cross filesystems (no
+atomic `rename(2)`), the protocol is **copy → verify hash → atomically swap the reference → reclaim the
+source**, with the DB reference as the commit point so an interruption is recoverable. No non-atomic
+cross-device `rename` is ever used.
+
+### Invariant check
+
+| Invariant (from ADR-003) | How B + content-addressing satisfies it |
+|---|---|
+| DB + FS updates recoverable after interruption | commit-last ingest; orphan `tmp/` sweep; reference-swap as commit point for moves |
+| A user-visible move never rewrites content | moves are projection operations; the content-addressed object never moves |
+| Historical versions never surface as duplicate current assets | the object store is never browsed; the UI resolves current via the DB pointer |
+| Path traversal / symlink escape rejected | canonicalize + assert under `STORAGE_ROOT` on every access |
+| Every stored file reconciles to an `AssetVersion` + hash | filename *is* the hash; `asset_version.content_hash` is unique/indexed |
 
 ## Decision
 
-*[Open — must be worked and Accepted before M1 storage design begins, per the STOP-on-open-ADR rule.]*
+*[Proposed for acceptance — pending operator review. On acceptance: Option B with a content-addressed
+BLAKE3 internal object store, as recommended above; the browsable projection and cross-filesystem move
+protocol are directionally set here but finalized when their operators are built in M2/M3. M1 builds only
+the internal object store, ingest, and integrity reconciliation.]*

--- a/docs/decisions/ADR-011-storage-tree-layout.md
+++ b/docs/decisions/ADR-011-storage-tree-layout.md
@@ -1,9 +1,9 @@
 # 011: Storage Tree Layout and Cross-Filesystem Moves
 
-**Status:** Proposed
-**Date:** 2026-08-19
-**Context:** Builds on [ADR-003 — Storage layout & asset
-identity](ADR-003-storage-layout-and-asset-identity.md), which settled asset identity — a stable `Asset`
+**Status:** Proposed · **Date:** 2026-08-19
+
+**Context:** Builds on [ADR-003 — Asset identity & content
+revisions](ADR-003-storage-layout-and-asset-identity.md), which settled asset identity — a stable `Asset`
 surrogate plus immutable, content-hashed `AssetVersion` byte states — and deliberately left on-disk
 layout and move semantics open. Those govern interruption recovery and data safety, so they are decided
 here, and must be Accepted before any storage code is written.

--- a/docs/decisions/ADR-011-storage-tree-layout.md
+++ b/docs/decisions/ADR-011-storage-tree-layout.md
@@ -2,21 +2,17 @@
 
 **Status:** Proposed
 **Date:** 2026-08-19
-**Context:** M0 of [RFC #213](https://github.com/sidereal-io/sidereal/issues/213). Split out of
-[ADR-003](ADR-003-storage-layout-and-asset-identity.md), which settled Asset/AssetVersion **identity**
-but explicitly left the **on-disk layout** and **move semantics** open. Those govern interruption
-recovery and data safety, so they get their own decision rather than lingering inside an accepted ADR.
-
-**This ADR gates M1.** Per the [STOP-on-open-ADR rule](../../AGENTS.md#open-adrs-block-design--stop), no
-M1 storage design may assume an answer here while this ADR is Proposed — it must be worked with the
-operator and Accepted first.
+**Context:** Builds on [ADR-003 — Storage layout & asset
+identity](ADR-003-storage-layout-and-asset-identity.md), which settled asset identity — a stable `Asset`
+surrogate plus immutable, content-hashed `AssetVersion` byte states — and deliberately left on-disk
+layout and move semantics open. Those govern interruption recovery and data safety, so they are decided
+here, and must be Accepted before any storage code is written.
 
 ## Problem
 
-ADR-003 established that identity does not prescribe layout: an `Asset` is a stable surrogate, each
-`AssetVersion` is an immutable content-addressed byte state, and Sidereal is the system of record that
-renames, moves, and organises files. Two questions remain open and must be answered before code touches
-a real tree:
+Identity does not prescribe layout: an `Asset` is a stable surrogate, each `AssetVersion` is an
+immutable content-hashed byte state, and Sidereal is the system of record that renames, moves, and
+organises files. Two questions remain open and must be answered before code touches a real tree:
 
 1. **The tree shape.** How are user-visible originals, derived renditions, and superseded versions laid
    out on disk — one user-meaningful tree, a split between a browsable tree and a protected internal
@@ -25,7 +21,7 @@ a real tree:
 2. **Cross-filesystem move behavior.** How is a user-visible move performed and made crash-safe when the
    source and destination are on different filesystems (where an atomic `rename(2)` is unavailable)?
 
-## Invariants (inherited from ADR-003, binding on any option)
+## Invariants (binding on any option)
 
 Whatever layout and move strategy are chosen must satisfy:
 
@@ -45,20 +41,21 @@ Originals and current renditions live in one tree organised by target/session/da
 are flagged in the database but not surfaced as separate current files.
 
 - **Pro:** what the user browses on disk *is* the managed tree — no indirection.
-- **Con:** the organizing keys (target, session, date) are astro **facets** that do not exist until M3,
-  and the tree must be addressable *now* (M1). It couples the physical store to domain vocabulary the
-  core is supposed to stay ignorant of, and every rename/move rewrites where real bytes live — the exact
-  operation most at risk from a crash.
+- **Con:** the organizing keys (target, session, date) are domain-specific values a domain-agnostic core
+  cannot depend on, and they are not populated until a domain pack classifies the asset — yet the store
+  must be addressable from the first ingest. It couples the physical store to vocabulary the core stays
+  ignorant of, and every rename/move rewrites where real bytes live — the operation most at risk from a
+  crash.
 
 ### Option B: Split — protected internal object store + browsable projection
 
 The bytes of every `AssetVersion` (originals, renditions, superseded alike) live in a protected internal
 store the UI never lists. A separate **browsable** tree organised by target/session/date is a
-*projection* over that store, materialized later (M2/M3) when organize/move operators and astro facets
-exist. A user-visible move is a projection operation; it never rewrites the stored bytes.
+*projection* over that store, materialized later once organize/move operators and domain facets exist. A
+user-visible move is a projection operation; it never rewrites the stored bytes.
 
 - **Pro:** the internal store is domain-agnostic and stable; user-visible reorganisation can never
-  corrupt byte truth; M1 builds only the internal store and defers the projection cleanly.
+  corrupt byte truth; the first build ships only the internal store and defers the projection cleanly.
 - **Con:** two layers, and the projection's materialization mechanism (symlink / hardlink / reflink /
   copy) is a later sub-decision.
 
@@ -68,15 +65,14 @@ Independently of A/B, the internal store can name a version file by its **opaque
 **BLAKE3 content hash** (git-object style). Content-hash naming gives uniform directory fan-out by
 construction (a night's session spreads evenly, where a time-ordered UUID prefix would cluster), free
 content dedup, immutable-friendly files, and self-reconciliation (the filename *is* the hash). Its cost
-is that the path is opaque to a human starting from a UI id — mitigated by storing and surfacing the
-`storage_path`/`content_hash` mapping as read-only metadata ([#217](https://github.com/sidereal-io/sidereal/issues/217),
-per ADR-008) — and hash-refcounted GC.
+is that the path is opaque to a human starting from a UI id — mitigated by storing the
+storage-path/content-hash mapping as read-only metadata surfaced in the UI — and hash-refcounted GC.
 
 ## Recommendation
 
 **Option B, with the internal object store content-addressed by BLAKE3.**
 
-**Internal object store** — the only part M1 builds:
+**Internal object store** — the only part the first storage build ships:
 
 ```
 {STORAGE_ROOT}/
@@ -84,35 +80,34 @@ per ADR-008) — and hash-refcounted GC.
   tmp/{uuid}                     # ingest staging, same filesystem as store/
 ```
 
-- **Atomic ingest:** copy the candidate into `tmp/` (**copy, never move** — filesystem-safety per
-  [migration.md](../architecture/migration.md)); BLAKE3-hash, stat, sniff format; **dedup by hash** (an
+- **Atomic ingest:** copy the candidate into `tmp/` (**copy, never move** — an in-place move during
+  ingest is the crash risk we are eliminating); BLAKE3-hash, stat, sniff format; **dedup by hash** (an
   existing hash shares the file); `fsync`; **atomic `rename` into `store/`**; then commit the DB row.
   Commit-last ordering means a crash leaves at worst an orphan `tmp/` file (swept on startup), never a DB
   row pointing at nothing.
-- **Integrity reconciliation** (identity/versioning rules in [ADR-003](ADR-003-storage-layout-and-asset-identity.md)):
-  re-hash on a `verify` pass; a mismatch is recorded (`integrity_mismatch`) and needs an explicit
-  adopt/restore/ignore, never a silent update; a missing file marks the Asset unavailable without
-  deleting identity/versions/lineage.
+- **Integrity reconciliation:** re-hash on a `verify` pass; a mismatch is recorded
+  (`integrity_mismatch`) and needs an explicit adopt/restore/ignore, never a silent update; a missing
+  file marks the Asset unavailable without deleting identity, versions, or lineage.
 - **Path safety:** every path canonicalized and asserted under `STORAGE_ROOT`; `..` traversal and symlink
   escape rejected.
-- **GC:** hash-**refcounted** — a stored file is deletable only when no `asset_version`, lineage edge,
-  Operation Run, hold, or migration audit references its hash (ADR-003 retention). M1 records references;
+- **GC:** hash-**refcounted** — a stored file is deletable only when no asset version, lineage edge,
+  operation run, hold, or migration audit references its hash. The first build records references only;
   it does not garbage-collect.
 
-**Browsable projection** — *deferred, not M1:* a target/session/date tree materialized as links over the
-object store, built when organize/move operators and astro facets land (M2/M3). Because it is a
-projection, a user-visible move/rename changes only the projection, never the stored bytes. The
-materialization mechanism (symlink / hardlink / reflink / copy) is settled then; whichever is chosen,
-bytes are preserved.
+**Browsable projection** — *deferred:* a target/session/date tree materialized as links over the object
+store, built once organize/move operators and domain facets exist. Because it is a projection, a
+user-visible move/rename changes only the projection, never the stored bytes. The materialization
+mechanism (symlink / hardlink / reflink / copy) is settled then; whichever is chosen, bytes are
+preserved.
 
-**Cross-filesystem moves** — *deferred, not M1:* when a user-visible move must cross filesystems (no
-atomic `rename(2)`), the protocol is **copy → verify hash → atomically swap the reference → reclaim the
+**Cross-filesystem moves** — *deferred:* when a user-visible move must cross filesystems (no atomic
+`rename(2)`), the protocol is **copy → verify hash → atomically swap the reference → reclaim the
 source**, with the DB reference as the commit point so an interruption is recoverable. No non-atomic
 cross-device `rename` is ever used.
 
 ### Invariant check
 
-| Invariant (from ADR-003) | How B + content-addressing satisfies it |
+| Invariant | How B + content-addressing satisfies it |
 |---|---|
 | DB + FS updates recoverable after interruption | commit-last ingest; orphan `tmp/` sweep; reference-swap as commit point for moves |
 | A user-visible move never rewrites content | moves are projection operations; the content-addressed object never moves |
@@ -124,5 +119,5 @@ cross-device `rename` is ever used.
 
 *[Proposed for acceptance — pending operator review. On acceptance: Option B with a content-addressed
 BLAKE3 internal object store, as recommended above; the browsable projection and cross-filesystem move
-protocol are directionally set here but finalized when their operators are built in M2/M3. M1 builds only
-the internal object store, ingest, and integrity reconciliation.]*
+protocol are directionally set here but finalized when their operators are built. The first storage build
+delivers only the internal object store, ingest, and integrity reconciliation.]*

--- a/docs/decisions/ADR-012-embedded-scripting-engine.md
+++ b/docs/decisions/ADR-012-embedded-scripting-engine.md
@@ -1,0 +1,77 @@
+# 012: Embedded Scripting Engine
+
+**Status:** Proposed · **Date:** 2026-08-20
+
+**Context:** Builds on [ADR-001 — Plugin contract & execution profiles](ADR-001-plugin-boundary.md),
+which established an embedded-script execution profile as the default public extension surface and
+deliberately left the engine choice open. This ADR picks that engine.
+
+## Problem
+
+The embedded-script profile runs untrusted, user-authored plugin code in-process, inside the Rust
+backend. It needs an engine that is safe to embed and controllable by the host, because a plugin must
+not be able to exhaust resources, block indefinitely, or reach past the capability-limited
+`AssetContext`. The engine must support:
+
+- **Cancellation** — the host can abort a running script mid-execution.
+- **Operation and memory limits** — bounded work per call, so a script cannot hang or OOM the process.
+- **Async host calls** — `AssetContext` operations are async (byte access, HTTP, emitting assets); the
+  engine must call back into async host functions without blocking a runtime thread.
+- **Manifest-driven loading** — a plugin bundle's declared entry points load and run deterministically.
+- **A clean capability boundary** — the script sees only what the host injects, with no ambient
+  filesystem, network, or process access.
+
+The question is which embeddable engine best meets these under a Rust host, and how much confidence we
+have before committing.
+
+## Options
+
+### Option A: Rhai
+
+**Pros:**
+- Purpose-built for embedding in Rust; native `rust`-side integration, no FFI.
+- Built-in operation counting, and support for memory/depth limits and cancellation.
+- Simple, familiar Rust-like syntax for plugin authors.
+
+**Cons:**
+- Interpreted and comparatively slow; unsuited to hot-path work (which is why hot paths stay built-in Rust).
+- Async host calls need care — the engine is synchronous at its core.
+
+### Option B: Rune
+
+**Pros:**
+- Designed for Rust embedding with first-class `async` support, easing async `AssetContext` calls.
+- Modern language features and a bytecode VM.
+
+**Cons:**
+- Younger and less battle-tested than Rhai; smaller ecosystem.
+- Resource-limit and sandboxing primitives less proven for hostile input.
+
+### Option C: Lua (via mlua/rlua)
+
+**Pros:**
+- Mature, widely understood embedding language with a large author pool.
+- Fast interpreter; long track record as an embedded scripting language.
+
+**Cons:**
+- Binds to a C library — adds a non-Rust build dependency and an FFI surface on the component that runs
+  untrusted code.
+- Async and fine-grained resource limits require extra host machinery rather than being native.
+
+## Recommendation
+
+**Option A — Rhai**, contingent on a spike. It is the most natural fit for an in-process Rust host and
+ships the host-side controls the profile requires — operation limits and cancellation — without an FFI
+dependency, which matters most on the component that runs untrusted code. Its weakness is performance,
+but the profile is explicitly for lightweight Operators, Sources, and Sinks; anything performance-
+sensitive stays in the built-in Rust profile.
+
+Because this locks in the public extension surface, the choice is ratified only after a spike proves
+Rhai against every requirement above — cancellation, operation/memory limits, async host calls, manifest
+loading, and the `AssetContext` API — on a real plugin. **Rune and Lua remain fallbacks** if the spike
+surfaces a blocker, Rune being the leading alternative for its native async.
+
+## Decision
+
+Pending the spike. On success, this ADR moves to Accepted with Rhai; on a blocker, it is re-decided in
+favour of the surviving fallback.


### PR DESCRIPTION
## What & why

Two threads, both docs-only, on top of the merged #244 work.

### 1. Resolve the ADRs that gate M1 design (from the #217 session)

**ADR-005 — Accepted (Option C: new shell, port components).** The data layer is rewritten under any option; Option C keeps the expensive working presentational pieces (deep-zoom viewer, Aladin sky map, admin forms) and takes structural freedom where the asset/collection/lineage model reshapes the UI. Its two conditions (contributor conversation, green v0.10.x Playwright baseline) are scoped to the **frontend build**, not this direction-setting call. Consequence: the first minimal read-only view is the first screen of this new shell, not throwaway work.

**ADR-011 — Drafted, still Proposed (needs your accept).** Storage tree layout + cross-filesystem moves, split out of ADR-003. Recommendation: a protected internal object store **content-addressed by BLAKE3** (uniform fan-out, free dedup, self-reconciling filenames) plus a browsable projection deferred until its operators exist; the first storage build ships only the internal store (atomic copy-ingest, integrity reconciliation, path-safety, hash-refcounted GC bookkeeping). Includes an invariant-check table. The Decision reads *"proposed for acceptance"* — **review it and, if it's right, I'll flip Status → Accepted in a follow-up.**

### 2. Make ADRs stand on their own (one-reference cap)

ADRs had grown a web of cross-references — milestones, issues, sibling docs, and each other — inside their Pros/Cons, forcing a reader to load unrelated context to evaluate a tradeoff. New convention, encoded in `ADR-000-template.md` and `AGENTS.md` and applied across all ten decided ADRs:

- **At most one link to another ADR**, in Context, with **number + title** so the number needs no decoding.
- **No references to issues, milestones, or the RFC** in an ADR body — they're tracking/plan artifacts, not standing context. Sequencing is expressed as a condition ("once the organize/move operators exist"), never a milestone number.
- Sibling-doc links dropped from ADR bodies; their substance is stated inline.

Worst case ADR-011 went **21 references → 1**. Net dependencies are now just the genuine couplings (001↔007, 002→001, 003→011, 006→008, 008→003, 010→004); 004/005/009 reference nothing. The rule is grep-checkable, so it's a one-line review/CI catch going forward.

### Index propagation
ADR-005's status flows through the architecture reference (header, decision table, intro, Design-facts note) and `roadmap.md`; ADR-011 is the last open, M1-gating ADR.

## Notes
- The M1 design itself lives in the #217 issue body (per the Feature & Bug Workflow), not this PR.
- No code changes — docs only.

Refs #217, #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
